### PR TITLE
Cpe Store

### DIFF
--- a/.env
+++ b/.env
@@ -10,3 +10,11 @@ SOAP_USER=20123456789MODDATOS
 SOAP_PASS=moddatos
 SIGN_PASS=greenter
 ###< application ##
+
+###> doctrine/doctrine-bundle ###
+# Format described at https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url
+# For an SQLite database, use: "sqlite:///%kernel.project_dir%/var/data.db"
+# For a PostgreSQL database, use: "postgresql://db_user:db_password@127.0.0.1:5432/db_name?serverVersion=11&charset=utf8"
+# IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml
+DATABASE_URL=mysql://db_user:db_password@127.0.0.1:3306/db_name?serverVersion=5.7
+###< doctrine/doctrine-bundle ###

--- a/.env
+++ b/.env
@@ -16,5 +16,5 @@ SIGN_PASS=greenter
 # For an SQLite database, use: "sqlite:///%kernel.project_dir%/var/data.db"
 # For a PostgreSQL database, use: "postgresql://db_user:db_password@127.0.0.1:5432/db_name?serverVersion=11&charset=utf8"
 # IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml
-DATABASE_URL=mysql://db_user:db_password@127.0.0.1:3306/db_name?serverVersion=5.7
+DATABASE_URL="sqlite:///%kernel.project_dir%/var/data.db"
 ###< doctrine/doctrine-bundle ###

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,5 @@
+# define your env variables for the test env here
+KERNEL_CLASS='App\Kernel'
+APP_SECRET='$ecretf0rt3st'
+SYMFONY_DEPRECATIONS_HELPER=999999
+PANTHER_APP_ENV=panther

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -32,3 +32,6 @@ jobs:
 
     - name: PHPStan Lint
       run: composer run-script lint:ci
+
+    - name: Unit Tests
+      run: php bin/phpunit

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -31,4 +31,4 @@ jobs:
       run: composer install --prefer-dist --no-progress --no-suggest
 
     - name: PHPStan Lint
-      run: vendor/bin/phpstan analyse
+      run: composer run-script lint:ci

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,9 @@
 /var/
 /vendor/
 ###< symfony/framework-bundle ###
+
+###> symfony/phpunit-bridge ###
+.phpunit
+.phpunit.result.cache
+/phpunit.xml
+###< symfony/phpunit-bridge ###

--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -2,4 +2,4 @@
 
 namespace PHPSTORM_META;
 
-override(\App\Services\Mapper::map(0, 1), type(1));
+override(\App\Services\Util\Mapper::map(0, 1), type(1));

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ Una implementación de SUNAT Soap Server para recepcionar comprobantes electrón
 **Alternativa a SUNAT BETA**
 - Realizar pruebas con diferentes código de respuestas que el servicio de SUNAT no ofrece.
 - Soporte de comprobantes extensos (_si envías un CPE con 300 items al servicio de SUNAT, se cae_).
-- Verificación de Credenciales
-- Rechazo de comprobantes
+- Endpoint unificado para todos los comprobantes.
+- Verificación de Credenciales.
+- Rechazo de comprobantes.
 - Consulta de CDR (_SUNAT no posee un servicio BETA para consultar CDR_).
 - Almacenamiento de comprobantes enviados.
 

--- a/README.md
+++ b/README.md
@@ -3,10 +3,13 @@
 
 Una implementación de SUNAT Soap Server para recepcionar comprobantes electrónicos.
 
-Propósito
-- **Mock Server**, para realizar pruebas con diferentes respuestas que 
-actualmente el servicio de SUNAT no ofrece.
-- Alternativa al servicio BETA de SUNAT.
+**Alternativa a SUNAT BETA**
+- Realizar pruebas con diferentes código de respuestas que el servicio de SUNAT no ofrece.
+- Soporte de comprobantes extensos (_si envías un CPE con 300 items al servicio de SUNAT, se cae_).
+- Verificación de Credenciales
+- Rechazo de comprobantes
+- Consulta de CDR (_SUNAT no posee un servicio BETA para consultar CDR_).
+- Almacenamiento de comprobantes enviados.
 
 LIVE (Pruebas)
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ La especificación del servicio la encontrarás en http://127.0.0.1:8000/ol-ti-i
 - `sendBill` :white_check_mark:
 - `sendSummary` :white_check_mark:
 - `sendPack` :hourglass:
-- `getStatus` :hourglass:
-- `getStatusCdr` :hourglass:
+- `getStatus` :white_check_mark:
+- `getStatusCdr` :white_check_mark:
 
 **Credenciales**
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ LIVE (Pruebas)
 
 
 ## Build
+Crear base de datos de prueba en la ruta `./var/data.db`.
+```
+php composer/DoctrineMigrations.php
+```
+
 Ejecutar (require `PHP +7.4`)
 ```bash
 php -S 127.0.0.1:8000 -t public

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ LIVE (Pruebas)
 
 
 ## Build
-Ejecutar
+Ejecutar (require `PHP +7.4`)
 ```bash
 php -S 127.0.0.1:8000 -t public
 ```

--- a/bin/phpunit
+++ b/bin/phpunit
@@ -1,0 +1,13 @@
+#!/usr/bin/env php
+<?php
+
+if (!file_exists(dirname(__DIR__).'/vendor/symfony/phpunit-bridge/bin/simple-phpunit.php')) {
+    echo "Unable to find the `simple-phpunit.php` script in `vendor/symfony/phpunit-bridge/bin/`.\n";
+    exit(1);
+}
+
+if (false === getenv('SYMFONY_PHPUNIT_DIR')) {
+    putenv('SYMFONY_PHPUNIT_DIR='.__DIR__.'/.phpunit');
+}
+
+require dirname(__DIR__).'/vendor/symfony/phpunit-bridge/bin/simple-phpunit.php';

--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,8 @@
         },
         "post-install-cmd": [
             "@auto-scripts",
-            "@php composer/XsltDownloader.php"
+            "@php composer/XsltDownloader.php",
+            "@php composer/DoctrineMigrations.php"
         ],
         "post-update-cmd": [
             "@auto-scripts"

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,10 @@
         "ext-dom": "*",
         "ext-iconv": "*",
         "ext-soap": "*",
+        "composer/package-versions-deprecated": "^1.11",
+        "doctrine/doctrine-bundle": "^2.1",
+        "doctrine/doctrine-migrations-bundle": "^3.0",
+        "doctrine/orm": "^2.7",
         "greenter/cpe-validator": "^4.0",
         "greenter/ubl-validator": "^2.1",
         "greenter/ws": "^4.0",
@@ -26,7 +30,8 @@
         "twig/twig": "^2.12|^3.0"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12.42"
+        "phpstan/phpstan": "^0.12.42",
+        "symfony/maker-bundle": "^1.21"
     },
     "config": {
         "optimize-autoloader": true,

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "MIT",
     "require": {
-        "php": "^7.3",
+        "php": "^7.4",
         "ext-ctype": "*",
         "ext-dom": "*",
         "ext-iconv": "*",

--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,9 @@
         ],
         "post-update-cmd": [
             "@auto-scripts"
-        ]
+        ],
+        "lint": "phpstan analyse",
+        "lint:ci": "phpstan analyse --error-format=github"
     },
     "conflict": {
         "symfony/symfony": "*"

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
     },
     "require-dev": {
         "phpstan/phpstan": "^0.12.42",
+        "symfony/browser-kit": "5.1.*",
         "symfony/maker-bundle": "^1.21",
         "symfony/phpunit-bridge": "^5.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
     },
     "require-dev": {
         "phpstan/phpstan": "^0.12.42",
-        "symfony/maker-bundle": "^1.21"
+        "symfony/maker-bundle": "^1.21",
+        "symfony/phpunit-bridge": "^5.1"
     },
     "config": {
         "optimize-autoloader": true,

--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,8 @@
             "assets:install %PUBLIC_DIR%": "symfony-cmd"
         },
         "post-install-cmd": [
-            "@auto-scripts"
+            "@auto-scripts",
+            "@php composer/XsltDownloader.php"
         ],
         "post-update-cmd": [
             "@auto-scripts"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "afc63e69f1cf2e187e178ccf1cf7d1d0",
+    "content-hash": "5c8c916d43b15c7f4f435c70204e1c8f",
     "packages": [
         {
             "name": "composer/package-versions-deprecated",
@@ -5621,6 +5621,85 @@
                 }
             ],
             "time": "2020-08-29T18:05:46+00:00"
+        },
+        {
+            "name": "symfony/phpunit-bridge",
+            "version": "v5.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/phpunit-bridge.git",
+                "reference": "e7d37c91486a0f9eed58a8c23822e1870ea36db5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/e7d37c91486a0f9eed58a8c23822e1870ea36db5",
+                "reference": "e7d37c91486a0f9eed58a8c23822e1870ea36db5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0|<6.4,>=6.0|9.1.2"
+            },
+            "suggest": {
+                "symfony/error-handler": "For tracking deprecated interfaces usages at runtime with DebugClassLoader"
+            },
+            "bin": [
+                "bin/simple-phpunit"
+            ],
+            "type": "symfony-bridge",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.1-dev"
+                },
+                "thanks": {
+                    "name": "phpunit/phpunit",
+                    "url": "https://github.com/sebastianbergmann/phpunit"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Bridge\\PhpUnit\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony PHPUnit Bridge",
+            "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-09-01T13:16:17+00:00"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a8c117ecb474724ea3a25f71865114d2",
+    "content-hash": "afc63e69f1cf2e187e178ccf1cf7d1d0",
     "packages": [
         {
             "name": "composer/package-versions-deprecated",
@@ -2406,16 +2406,16 @@
         },
         {
             "name": "symfony/cache",
-            "version": "v5.1.3",
+            "version": "v5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache.git",
-                "reference": "a9ac09a5e9786b734a4baa98158c2cd3251f1e4c"
+                "reference": "c31bdd71f30435baff03693e684469c7ecb3ca1a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/a9ac09a5e9786b734a4baa98158c2cd3251f1e4c",
-                "reference": "a9ac09a5e9786b734a4baa98158c2cd3251f1e4c",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/c31bdd71f30435baff03693e684469c7ecb3ca1a",
+                "reference": "c31bdd71f30435baff03693e684469c7ecb3ca1a",
                 "shasum": ""
             },
             "require": {
@@ -2496,20 +2496,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-23T17:22:30+00:00"
+            "time": "2020-09-01T05:52:18+00:00"
         },
         {
             "name": "symfony/cache-contracts",
-            "version": "v2.1.3",
+            "version": "v2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache-contracts.git",
-                "reference": "9771a09d2e6b84ecb8c9f0a7dbc72ee92aeba009"
+                "reference": "8034ca0b61d4dd967f3698aaa1da2507b631d0cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache-contracts/zipball/9771a09d2e6b84ecb8c9f0a7dbc72ee92aeba009",
-                "reference": "9771a09d2e6b84ecb8c9f0a7dbc72ee92aeba009",
+                "url": "https://api.github.com/repos/symfony/cache-contracts/zipball/8034ca0b61d4dd967f3698aaa1da2507b631d0cb",
+                "reference": "8034ca0b61d4dd967f3698aaa1da2507b631d0cb",
                 "shasum": ""
             },
             "require": {
@@ -2522,7 +2522,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev"
+                    "dev-master": "2.2-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -2572,20 +2572,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-06T13:23:11+00:00"
+            "time": "2020-09-07T11:33:47+00:00"
         },
         {
             "name": "symfony/config",
-            "version": "v5.1.3",
+            "version": "v5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "cf63f0613a6c6918e96db39c07a43b01e19a0773"
+                "reference": "22f961ddffdc81389670b2ca74a1cc0213761ec0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/cf63f0613a6c6918e96db39c07a43b01e19a0773",
-                "reference": "cf63f0613a6c6918e96db39c07a43b01e19a0773",
+                "url": "https://api.github.com/repos/symfony/config/zipball/22f961ddffdc81389670b2ca74a1cc0213761ec0",
+                "reference": "22f961ddffdc81389670b2ca74a1cc0213761ec0",
                 "shasum": ""
             },
             "require": {
@@ -2652,20 +2652,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-15T10:53:22+00:00"
+            "time": "2020-08-17T07:48:54+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v5.1.3",
+            "version": "v5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "2226c68009627934b8cfc01260b4d287eab070df"
+                "reference": "186f395b256065ba9b890c0a4e48a91d598fa2cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/2226c68009627934b8cfc01260b4d287eab070df",
-                "reference": "2226c68009627934b8cfc01260b4d287eab070df",
+                "url": "https://api.github.com/repos/symfony/console/zipball/186f395b256065ba9b890c0a4e48a91d598fa2cf",
+                "reference": "186f395b256065ba9b890c0a4e48a91d598fa2cf",
                 "shasum": ""
             },
             "require": {
@@ -2745,20 +2745,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-06T13:23:11+00:00"
+            "time": "2020-09-02T07:07:40+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v5.1.3",
+            "version": "v5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "c45c3f26d2ae7c5239e5ad420b0c2717dbbc0bcb"
+                "reference": "48d6890e12ce9cd8e68aaa4fb72010139312fd73"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/c45c3f26d2ae7c5239e5ad420b0c2717dbbc0bcb",
-                "reference": "c45c3f26d2ae7c5239e5ad420b0c2717dbbc0bcb",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/48d6890e12ce9cd8e68aaa4fb72010139312fd73",
+                "reference": "48d6890e12ce9cd8e68aaa4fb72010139312fd73",
                 "shasum": ""
             },
             "require": {
@@ -2834,20 +2834,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-23T08:36:24+00:00"
+            "time": "2020-09-01T18:07:16+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v2.1.3",
+            "version": "v2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "5e20b83385a77593259c9f8beb2c43cd03b2ac14"
+                "reference": "5fa56b4074d1ae755beb55617ddafe6f5d78f665"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/5e20b83385a77593259c9f8beb2c43cd03b2ac14",
-                "reference": "5e20b83385a77593259c9f8beb2c43cd03b2ac14",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/5fa56b4074d1ae755beb55617ddafe6f5d78f665",
+                "reference": "5fa56b4074d1ae755beb55617ddafe6f5d78f665",
                 "shasum": ""
             },
             "require": {
@@ -2856,7 +2856,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev"
+                    "dev-master": "2.2-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -2898,7 +2898,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-06-06T08:49:21+00:00"
+            "time": "2020-09-07T11:33:47+00:00"
         },
         {
             "name": "symfony/doctrine-bridge",
@@ -3016,7 +3016,7 @@
         },
         {
             "name": "symfony/dotenv",
-            "version": "v5.1.3",
+            "version": "v5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dotenv.git",
@@ -3088,16 +3088,16 @@
         },
         {
             "name": "symfony/error-handler",
-            "version": "v5.1.3",
+            "version": "v5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "4a0d1673a4731c3cb2dea3580c73a676ecb9ed4b"
+                "reference": "525636d4b84e06c6ca72d96b6856b5b169416e6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/4a0d1673a4731c3cb2dea3580c73a676ecb9ed4b",
-                "reference": "4a0d1673a4731c3cb2dea3580c73a676ecb9ed4b",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/525636d4b84e06c6ca72d96b6856b5b169416e6a",
+                "reference": "525636d4b84e06c6ca72d96b6856b5b169416e6a",
                 "shasum": ""
             },
             "require": {
@@ -3155,20 +3155,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-23T08:36:24+00:00"
+            "time": "2020-08-17T10:01:29+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v5.1.3",
+            "version": "v5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "7827d55911f91c070fc293ea51a06eec80797d76"
+                "reference": "94871fc0a69c3c5da57764187724cdce0755899c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/7827d55911f91c070fc293ea51a06eec80797d76",
-                "reference": "7827d55911f91c070fc293ea51a06eec80797d76",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/94871fc0a69c3c5da57764187724cdce0755899c",
+                "reference": "94871fc0a69c3c5da57764187724cdce0755899c",
                 "shasum": ""
             },
             "require": {
@@ -3241,20 +3241,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-06-18T18:24:02+00:00"
+            "time": "2020-08-13T14:19:42+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v2.1.3",
+            "version": "v2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "f6f613d74cfc5a623fc36294d3451eb7fa5a042b"
+                "reference": "0ba7d54483095a198fa51781bc608d17e84dffa2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/f6f613d74cfc5a623fc36294d3451eb7fa5a042b",
-                "reference": "f6f613d74cfc5a623fc36294d3451eb7fa5a042b",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/0ba7d54483095a198fa51781bc608d17e84dffa2",
+                "reference": "0ba7d54483095a198fa51781bc608d17e84dffa2",
                 "shasum": ""
             },
             "require": {
@@ -3267,7 +3267,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev"
+                    "dev-master": "2.2-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -3317,20 +3317,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-06T13:23:11+00:00"
+            "time": "2020-09-07T11:33:47+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.1.3",
+            "version": "v5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "6e4320f06d5f2cce0d96530162491f4465179157"
+                "reference": "f7b9ed6142a34252d219801d9767dedbd711da1a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/6e4320f06d5f2cce0d96530162491f4465179157",
-                "reference": "6e4320f06d5f2cce0d96530162491f4465179157",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/f7b9ed6142a34252d219801d9767dedbd711da1a",
+                "reference": "f7b9ed6142a34252d219801d9767dedbd711da1a",
                 "shasum": ""
             },
             "require": {
@@ -3381,20 +3381,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-30T20:35:19+00:00"
+            "time": "2020-08-21T17:19:47+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v5.1.3",
+            "version": "v5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "4298870062bfc667cb78d2b379be4bf5dec5f187"
+                "reference": "2b765f0cf6612b3636e738c0689b29aa63088d5d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/4298870062bfc667cb78d2b379be4bf5dec5f187",
-                "reference": "4298870062bfc667cb78d2b379be4bf5dec5f187",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/2b765f0cf6612b3636e738c0689b29aa63088d5d",
+                "reference": "2b765f0cf6612b3636e738c0689b29aa63088d5d",
                 "shasum": ""
             },
             "require": {
@@ -3444,20 +3444,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-20T17:43:50+00:00"
+            "time": "2020-08-17T10:01:29+00:00"
         },
         {
             "name": "symfony/flex",
-            "version": "v1.9.1",
+            "version": "v1.9.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/flex.git",
-                "reference": "0e752e47d8382361ca2d7ef016f549828185ddb6"
+                "reference": "115e67f76ba95d70946a6e0b15d4578bf04927c3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/flex/zipball/0e752e47d8382361ca2d7ef016f549828185ddb6",
-                "reference": "0e752e47d8382361ca2d7ef016f549828185ddb6",
+                "url": "https://api.github.com/repos/symfony/flex/zipball/115e67f76ba95d70946a6e0b15d4578bf04927c3",
+                "reference": "115e67f76ba95d70946a6e0b15d4578bf04927c3",
                 "shasum": ""
             },
             "require": {
@@ -3507,20 +3507,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-14T15:18:33+00:00"
+            "time": "2020-09-14T14:58:36+00:00"
         },
         {
             "name": "symfony/framework-bundle",
-            "version": "v5.1.3",
+            "version": "v5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/framework-bundle.git",
-                "reference": "f9be9af9092f165b9b809d870289b57330301dc6"
+                "reference": "0607ca3cb7b79461a2e6a7c5d05e5cd6d2c14015"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/framework-bundle/zipball/f9be9af9092f165b9b809d870289b57330301dc6",
-                "reference": "f9be9af9092f165b9b809d870289b57330301dc6",
+                "url": "https://api.github.com/repos/symfony/framework-bundle/zipball/0607ca3cb7b79461a2e6a7c5d05e5cd6d2c14015",
+                "reference": "0607ca3cb7b79461a2e6a7c5d05e5cd6d2c14015",
                 "shasum": ""
             },
             "require": {
@@ -3654,20 +3654,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-23T08:36:24+00:00"
+            "time": "2020-08-30T09:59:07+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v5.1.3",
+            "version": "v5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "1f0d6627e680591c61e9176f04a0dc887b4e6702"
+                "reference": "41a4647f12870e9d41d9a7d72ff0614a27208558"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/1f0d6627e680591c61e9176f04a0dc887b4e6702",
-                "reference": "1f0d6627e680591c61e9176f04a0dc887b4e6702",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/41a4647f12870e9d41d9a7d72ff0614a27208558",
+                "reference": "41a4647f12870e9d41d9a7d72ff0614a27208558",
                 "shasum": ""
             },
             "require": {
@@ -3729,20 +3729,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-23T10:04:31+00:00"
+            "time": "2020-08-17T07:48:54+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v5.1.3",
+            "version": "v5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "d6dd8f6420e377970ddad0d6317d4ce4186fc6b3"
+                "reference": "3e32676e6cb5d2081c91a56783471ff8a7f7110b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/d6dd8f6420e377970ddad0d6317d4ce4186fc6b3",
-                "reference": "d6dd8f6420e377970ddad0d6317d4ce4186fc6b3",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/3e32676e6cb5d2081c91a56783471ff8a7f7110b",
+                "reference": "3e32676e6cb5d2081c91a56783471ff8a7f7110b",
                 "shasum": ""
             },
             "require": {
@@ -3842,20 +3842,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-24T04:22:56+00:00"
+            "time": "2020-09-02T08:15:18+00:00"
         },
         {
             "name": "symfony/monolog-bridge",
-            "version": "v5.1.3",
+            "version": "v5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/monolog-bridge.git",
-                "reference": "81e8c7692b78161a06f779c741ef21d80f217175"
+                "reference": "c312bf3de53a5e2b784224045d6e7d5c0abfe1c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/monolog-bridge/zipball/81e8c7692b78161a06f779c741ef21d80f217175",
-                "reference": "81e8c7692b78161a06f779c741ef21d80f217175",
+                "url": "https://api.github.com/repos/symfony/monolog-bridge/zipball/c312bf3de53a5e2b784224045d6e7d5c0abfe1c0",
+                "reference": "c312bf3de53a5e2b784224045d6e7d5c0abfe1c0",
                 "shasum": ""
             },
             "require": {
@@ -3925,7 +3925,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-06-18T18:24:02+00:00"
+            "time": "2020-08-17T07:42:30+00:00"
         },
         {
             "name": "symfony/monolog-bundle",
@@ -4384,16 +4384,16 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v5.1.3",
+            "version": "v5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "08c9a82f09d12ee048f85e76e0d783f82844eb5d"
+                "reference": "47b0218344cb6af25c93ca8ee1137fafbee5005d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/08c9a82f09d12ee048f85e76e0d783f82844eb5d",
-                "reference": "08c9a82f09d12ee048f85e76e0d783f82844eb5d",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/47b0218344cb6af25c93ca8ee1137fafbee5005d",
+                "reference": "47b0218344cb6af25c93ca8ee1137fafbee5005d",
                 "shasum": ""
             },
             "require": {
@@ -4472,20 +4472,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-06-18T18:24:02+00:00"
+            "time": "2020-08-10T08:03:57+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v2.1.3",
+            "version": "v2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "58c7475e5457c5492c26cc740cc0ad7464be9442"
+                "reference": "d15da7ba4957ffb8f1747218be9e1a121fd298a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/58c7475e5457c5492c26cc740cc0ad7464be9442",
-                "reference": "58c7475e5457c5492c26cc740cc0ad7464be9442",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d15da7ba4957ffb8f1747218be9e1a121fd298a1",
+                "reference": "d15da7ba4957ffb8f1747218be9e1a121fd298a1",
                 "shasum": ""
             },
             "require": {
@@ -4498,7 +4498,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev"
+                    "dev-master": "2.2-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -4548,7 +4548,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-06T13:23:11+00:00"
+            "time": "2020-09-07T11:33:47+00:00"
         },
         {
             "name": "symfony/stopwatch",
@@ -4616,16 +4616,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v5.1.3",
+            "version": "v5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "f629ba9b611c76224feb21fe2bcbf0b6f992300b"
+                "reference": "0de4cc1e18bb596226c06a82e2e7e9bc6001a63a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/f629ba9b611c76224feb21fe2bcbf0b6f992300b",
-                "reference": "f629ba9b611c76224feb21fe2bcbf0b6f992300b",
+                "url": "https://api.github.com/repos/symfony/string/zipball/0de4cc1e18bb596226c06a82e2e7e9bc6001a63a",
+                "reference": "0de4cc1e18bb596226c06a82e2e7e9bc6001a63a",
                 "shasum": ""
             },
             "require": {
@@ -4697,20 +4697,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-08T08:27:49+00:00"
+            "time": "2020-08-17T07:48:54+00:00"
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "v2.1.3",
+            "version": "v2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "616a9773c853097607cf9dd6577d5b143ffdcd63"
+                "reference": "77ce1c3627c9f39643acd9af086631f842c50c4d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/616a9773c853097607cf9dd6577d5b143ffdcd63",
-                "reference": "616a9773c853097607cf9dd6577d5b143ffdcd63",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/77ce1c3627c9f39643acd9af086631f842c50c4d",
+                "reference": "77ce1c3627c9f39643acd9af086631f842c50c4d",
                 "shasum": ""
             },
             "require": {
@@ -4722,7 +4722,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev"
+                    "dev-master": "2.2-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -4772,20 +4772,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-06T13:23:11+00:00"
+            "time": "2020-09-07T11:33:47+00:00"
         },
         {
             "name": "symfony/twig-bridge",
-            "version": "v5.1.3",
+            "version": "v5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/twig-bridge.git",
-                "reference": "44bba5d7e5cb8a3ddeb640ae00938cc768c55797"
+                "reference": "4534dbfd47745a924beaa6e7c9d5462993bbd0a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/twig-bridge/zipball/44bba5d7e5cb8a3ddeb640ae00938cc768c55797",
-                "reference": "44bba5d7e5cb8a3ddeb640ae00938cc768c55797",
+                "url": "https://api.github.com/repos/symfony/twig-bridge/zipball/4534dbfd47745a924beaa6e7c9d5462993bbd0a5",
+                "reference": "4534dbfd47745a924beaa6e7c9d5462993bbd0a5",
                 "shasum": ""
             },
             "require": {
@@ -4888,11 +4888,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-06-30T17:59:51+00:00"
+            "time": "2020-08-26T14:33:04+00:00"
         },
         {
             "name": "symfony/twig-bundle",
-            "version": "v5.1.3",
+            "version": "v5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/twig-bundle.git",
@@ -4981,16 +4981,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v5.1.3",
+            "version": "v5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "2ebe1c7bb52052624d6dc1250f4abe525655d75a"
+                "reference": "b43a3905262bcf97b2510f0621f859ca4f5287be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/2ebe1c7bb52052624d6dc1250f4abe525655d75a",
-                "reference": "2ebe1c7bb52052624d6dc1250f4abe525655d75a",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/b43a3905262bcf97b2510f0621f859ca4f5287be",
+                "reference": "b43a3905262bcf97b2510f0621f859ca4f5287be",
                 "shasum": ""
             },
             "require": {
@@ -5067,11 +5067,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-06-24T13:36:18+00:00"
+            "time": "2020-08-17T07:42:30+00:00"
         },
         {
             "name": "symfony/var-exporter",
-            "version": "v5.1.3",
+            "version": "v5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-exporter.git",
@@ -5146,16 +5146,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v5.1.3",
+            "version": "v5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "ea342353a3ef4f453809acc4ebc55382231d4d23"
+                "reference": "a44bd3a91bfbf8db12367fa6ffac9c3eb1a8804a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/ea342353a3ef4f453809acc4ebc55382231d4d23",
-                "reference": "ea342353a3ef4f453809acc4ebc55382231d4d23",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/a44bd3a91bfbf8db12367fa6ffac9c3eb1a8804a",
+                "reference": "a44bd3a91bfbf8db12367fa6ffac9c3eb1a8804a",
                 "shasum": ""
             },
             "require": {
@@ -5219,7 +5219,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-20T17:43:50+00:00"
+            "time": "2020-08-26T08:30:57+00:00"
         },
         {
             "name": "twig/extra-bundle",
@@ -5629,7 +5629,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.3",
+        "php": "^7.4",
         "ext-ctype": "*",
         "ext-dom": "*",
         "ext-iconv": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5c8c916d43b15c7f4f435c70204e1c8f",
+    "content-hash": "f1f9039c56e6cb732b82ddb86ce37728",
     "packages": [
         {
             "name": "composer/package-versions-deprecated",
@@ -5538,6 +5538,155 @@
                 }
             ],
             "time": "2020-09-02T13:14:53+00:00"
+        },
+        {
+            "name": "symfony/browser-kit",
+            "version": "v5.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/browser-kit.git",
+                "reference": "b9545e08790be2d3d7d92306e339bbcd79f461e4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/b9545e08790be2d3d7d92306e339bbcd79f461e4",
+                "reference": "b9545e08790be2d3d7d92306e339bbcd79f461e4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/dom-crawler": "^4.4|^5.0"
+            },
+            "require-dev": {
+                "symfony/css-selector": "^4.4|^5.0",
+                "symfony/http-client": "^4.4|^5.0",
+                "symfony/mime": "^4.4|^5.0",
+                "symfony/process": "^4.4|^5.0"
+            },
+            "suggest": {
+                "symfony/process": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\BrowserKit\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony BrowserKit Component",
+            "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-06-24T13:36:18+00:00"
+        },
+        {
+            "name": "symfony/dom-crawler",
+            "version": "v5.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/dom-crawler.git",
+                "reference": "3ac31ffbc596e41ca081037b7d78fc7a853c0315"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/3ac31ffbc596e41ca081037b7d78fc7a853c0315",
+                "reference": "3ac31ffbc596e41ca081037b7d78fc7a853c0315",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php80": "^1.15"
+            },
+            "conflict": {
+                "masterminds/html5": "<2.6"
+            },
+            "require-dev": {
+                "masterminds/html5": "^2.6",
+                "symfony/css-selector": "^4.4|^5.0"
+            },
+            "suggest": {
+                "symfony/css-selector": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\DomCrawler\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony DomCrawler Component",
+            "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-08-12T08:45:47+00:00"
         },
         {
             "name": "symfony/maker-bundle",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,1455 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a50dfe4909d05a2652588ae2aa51678f",
+    "content-hash": "a8c117ecb474724ea3a25f71865114d2",
     "packages": [
+        {
+            "name": "composer/package-versions-deprecated",
+            "version": "1.11.99",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/package-versions-deprecated.git",
+                "reference": "c8c9aa8a14cc3d3bec86d0a8c3fa52ea79936855"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/package-versions-deprecated/zipball/c8c9aa8a14cc3d3bec86d0a8c3fa52ea79936855",
+                "reference": "c8c9aa8a14cc3d3bec86d0a8c3fa52ea79936855",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1.0 || ^2.0",
+                "php": "^7 || ^8"
+            },
+            "replace": {
+                "ocramius/package-versions": "1.11.99"
+            },
+            "require-dev": {
+                "composer/composer": "^1.9.3 || ^2.0@dev",
+                "ext-zip": "^1.13",
+                "phpunit/phpunit": "^6.5 || ^7"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PackageVersions\\Installer",
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PackageVersions\\": "src/PackageVersions"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be"
+                }
+            ],
+            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-08-25T05:50:16+00:00"
+        },
+        {
+            "name": "doctrine/annotations",
+            "version": "1.10.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/annotations.git",
+                "reference": "bfe91e31984e2ba76df1c1339681770401ec262f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/bfe91e31984e2ba76df1c1339681770401ec262f",
+                "reference": "bfe91e31984e2ba76df1c1339681770401ec262f",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "1.*",
+                "ext-tokenizer": "*",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/cache": "1.*",
+                "phpstan/phpstan": "^0.12.20",
+                "phpunit/phpunit": "^7.5 || ^9.1.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Docblock Annotations Parser",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "parser"
+            ],
+            "time": "2020-08-10T19:35:50+00:00"
+        },
+        {
+            "name": "doctrine/cache",
+            "version": "1.10.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/cache.git",
+                "reference": "13e3381b25847283a91948d04640543941309727"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/13e3381b25847283a91948d04640543941309727",
+                "reference": "13e3381b25847283a91948d04640543941309727",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/common": ">2.2,<2.4"
+            },
+            "require-dev": {
+                "alcaeus/mongo-php-adapter": "^1.1",
+                "doctrine/coding-standard": "^6.0",
+                "mongodb/mongodb": "^1.1",
+                "phpunit/phpunit": "^7.0",
+                "predis/predis": "~1.0"
+            },
+            "suggest": {
+                "alcaeus/mongo-php-adapter": "Required to use legacy MongoDB driver"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Cache\\": "lib/Doctrine/Common/Cache"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Cache library is a popular cache implementation that supports many different drivers such as redis, memcache, apc, mongodb and others.",
+            "homepage": "https://www.doctrine-project.org/projects/cache.html",
+            "keywords": [
+                "abstraction",
+                "apcu",
+                "cache",
+                "caching",
+                "couchdb",
+                "memcached",
+                "php",
+                "redis",
+                "xcache"
+            ],
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fcache",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-07-07T18:54:01+00:00"
+        },
+        {
+            "name": "doctrine/collections",
+            "version": "1.6.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/collections.git",
+                "reference": "55f8b799269a1a472457bd1a41b4f379d4cfba4a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/collections/zipball/55f8b799269a1a472457bd1a41b4f379d4cfba4a",
+                "reference": "55f8b799269a1a472457bd1a41b4f379d4cfba4a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^6.0",
+                "phpstan/phpstan-shim": "^0.9.2",
+                "phpunit/phpunit": "^7.0",
+                "vimeo/psalm": "^3.8.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Collections\\": "lib/Doctrine/Common/Collections"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Collections library that adds additional functionality on top of PHP arrays.",
+            "homepage": "https://www.doctrine-project.org/projects/collections.html",
+            "keywords": [
+                "array",
+                "collections",
+                "iterators",
+                "php"
+            ],
+            "time": "2020-07-27T17:53:49+00:00"
+        },
+        {
+            "name": "doctrine/common",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/common.git",
+                "reference": "a3c6479858989e242a2465972b4f7a8642baf0d4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/common/zipball/a3c6479858989e242a2465972b4f7a8642baf0d4",
+                "reference": "a3c6479858989e242a2465972b4f7a8642baf0d4",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/persistence": "^2.0",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^1.0",
+                "phpstan/phpstan": "^0.11",
+                "phpstan/phpstan-phpunit": "^0.11",
+                "phpunit/phpunit": "^7.0",
+                "squizlabs/php_codesniffer": "^3.0",
+                "symfony/phpunit-bridge": "^4.0.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\": "lib/Doctrine/Common"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Common project is a library that provides additional functionality that other Doctrine projects depend on such as better reflection support, persistence interfaces, proxies, event system and much more.",
+            "homepage": "https://www.doctrine-project.org/projects/common.html",
+            "keywords": [
+                "common",
+                "doctrine",
+                "php"
+            ],
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fcommon",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-06-05T16:59:53+00:00"
+        },
+        {
+            "name": "doctrine/dbal",
+            "version": "2.10.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/dbal.git",
+                "reference": "47433196b6390d14409a33885ee42b6208160643"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/47433196b6390d14409a33885ee42b6208160643",
+                "reference": "47433196b6390d14409a33885ee42b6208160643",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/cache": "^1.0",
+                "doctrine/event-manager": "^1.0",
+                "ext-pdo": "*",
+                "php": "^7.2"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^8.1",
+                "jetbrains/phpstorm-stubs": "^2019.1",
+                "nikic/php-parser": "^4.4",
+                "phpstan/phpstan": "^0.12.40",
+                "phpunit/phpunit": "^8.5.5",
+                "psalm/plugin-phpunit": "^0.10.0",
+                "symfony/console": "^2.0.5|^3.0|^4.0|^5.0",
+                "vimeo/psalm": "^3.14.2"
+            },
+            "suggest": {
+                "symfony/console": "For helpful console commands such as SQL execution and import of files."
+            },
+            "bin": [
+                "bin/doctrine-dbal"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.10.x-dev",
+                    "dev-develop": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\DBAL\\": "lib/Doctrine/DBAL"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Powerful PHP database abstraction layer (DBAL) with many features for database schema introspection and management.",
+            "homepage": "https://www.doctrine-project.org/projects/dbal.html",
+            "keywords": [
+                "abstraction",
+                "database",
+                "db2",
+                "dbal",
+                "mariadb",
+                "mssql",
+                "mysql",
+                "oci8",
+                "oracle",
+                "pdo",
+                "pgsql",
+                "postgresql",
+                "queryobject",
+                "sasql",
+                "sql",
+                "sqlanywhere",
+                "sqlite",
+                "sqlserver",
+                "sqlsrv"
+            ],
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fdbal",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-09-12T21:20:41+00:00"
+        },
+        {
+            "name": "doctrine/doctrine-bundle",
+            "version": "2.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/DoctrineBundle.git",
+                "reference": "f5153089993e1230f5d8acbd8e126014d5a63e17"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/DoctrineBundle/zipball/f5153089993e1230f5d8acbd8e126014d5a63e17",
+                "reference": "f5153089993e1230f5d8acbd8e126014d5a63e17",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/dbal": "^2.9.0|^3.0",
+                "doctrine/persistence": "^1.3.3|^2.0",
+                "doctrine/sql-formatter": "^1.0.1",
+                "php": "^7.1 || ^8.0",
+                "symfony/cache": "^4.3.3|^5.0",
+                "symfony/config": "^4.3.3|^5.0",
+                "symfony/console": "^3.4.30|^4.3.3|^5.0",
+                "symfony/dependency-injection": "^4.3.3|^5.0",
+                "symfony/doctrine-bridge": "^4.3.7|^5.0",
+                "symfony/framework-bundle": "^3.4.30|^4.3.3|^5.0",
+                "symfony/service-contracts": "^1.1.1|^2.0"
+            },
+            "conflict": {
+                "doctrine/orm": "<2.6",
+                "twig/twig": "<1.34|>=2.0,<2.4"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^6.0",
+                "doctrine/orm": "^2.6",
+                "ocramius/proxy-manager": "^2.1",
+                "phpunit/phpunit": "^7.5",
+                "symfony/phpunit-bridge": "^4.2",
+                "symfony/property-info": "^4.3.3|^5.0",
+                "symfony/proxy-manager-bridge": "^3.4|^4.3.3|^5.0",
+                "symfony/twig-bridge": "^3.4.30|^4.3.3|^5.0",
+                "symfony/validator": "^3.4.30|^4.3.3|^5.0",
+                "symfony/web-profiler-bundle": "^3.4.30|^4.3.3|^5.0",
+                "symfony/yaml": "^3.4.30|^4.3.3|^5.0",
+                "twig/twig": "^1.34|^2.12"
+            },
+            "suggest": {
+                "doctrine/orm": "The Doctrine ORM integration is optional in the bundle.",
+                "symfony/web-profiler-bundle": "To use the data collector."
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Bundle\\DoctrineBundle\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Doctrine Project",
+                    "homepage": "http://www.doctrine-project.org/"
+                }
+            ],
+            "description": "Symfony DoctrineBundle",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "database",
+                "dbal",
+                "orm",
+                "persistence"
+            ],
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fdoctrine-bundle",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-08-25T10:57:15+00:00"
+        },
+        {
+            "name": "doctrine/doctrine-migrations-bundle",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/DoctrineMigrationsBundle.git",
+                "reference": "96e730b0ffa0bb39c0f913c1966213f1674bf249"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/DoctrineMigrationsBundle/zipball/96e730b0ffa0bb39c0f913c1966213f1674bf249",
+                "reference": "96e730b0ffa0bb39c0f913c1966213f1674bf249",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/doctrine-bundle": "~1.0|~2.0",
+                "doctrine/migrations": "~3.0",
+                "php": "^7.2",
+                "symfony/framework-bundle": "~3.4|~4.0|~5.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^5.0",
+                "doctrine/orm": "^2.6",
+                "phpstan/phpstan": "^0.11",
+                "phpstan/phpstan-deprecation-rules": "^0.11",
+                "phpstan/phpstan-phpunit": "^0.11",
+                "phpstan/phpstan-strict-rules": "^0.11",
+                "phpunit/phpunit": "^6.4|^7.0"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Bundle\\MigrationsBundle\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Doctrine Project",
+                    "homepage": "http://www.doctrine-project.org"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony DoctrineMigrationsBundle",
+            "homepage": "https://www.doctrine-project.org",
+            "keywords": [
+                "dbal",
+                "migrations",
+                "schema"
+            ],
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fdoctrine-migrations-bundle",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-06-15T06:04:38+00:00"
+        },
+        {
+            "name": "doctrine/event-manager",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/event-manager.git",
+                "reference": "41370af6a30faa9dc0368c4a6814d596e81aba7f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/event-manager/zipball/41370af6a30faa9dc0368c4a6814d596e81aba7f",
+                "reference": "41370af6a30faa9dc0368c4a6814d596e81aba7f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/common": "<2.9@dev"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^6.0",
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\": "lib/Doctrine/Common"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "The Doctrine Event Manager is a simple PHP event system that was built to be used with the various Doctrine projects.",
+            "homepage": "https://www.doctrine-project.org/projects/event-manager.html",
+            "keywords": [
+                "event",
+                "event dispatcher",
+                "event manager",
+                "event system",
+                "events"
+            ],
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fevent-manager",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-29T18:28:51+00:00"
+        },
+        {
+            "name": "doctrine/inflector",
+            "version": "1.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/inflector.git",
+                "reference": "4650c8b30c753a76bf44fb2ed00117d6f367490c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/4650c8b30c753a76bf44fb2ed00117d6f367490c",
+                "reference": "4650c8b30c753a76bf44fb2ed00117d6f367490c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^7.0",
+                "phpstan/phpstan": "^0.11",
+                "phpstan/phpstan-phpunit": "^0.11",
+                "phpstan/phpstan-strict-rules": "^0.11",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Inflector\\": "lib/Doctrine/Common/Inflector",
+                    "Doctrine\\Inflector\\": "lib/Doctrine/Inflector"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Inflector is a small library that can perform string manipulations with regard to upper/lowercase and singular/plural forms of words.",
+            "homepage": "https://www.doctrine-project.org/projects/inflector.html",
+            "keywords": [
+                "inflection",
+                "inflector",
+                "lowercase",
+                "manipulation",
+                "php",
+                "plural",
+                "singular",
+                "strings",
+                "uppercase",
+                "words"
+            ],
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finflector",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-29T07:19:59+00:00"
+        },
+        {
+            "name": "doctrine/instantiator",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "f350df0268e904597e3bd9c4685c53e0e333feea"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/f350df0268e904597e3bd9c4685c53e0e333feea",
+                "reference": "f350df0268e904597e3bd9c4685c53e0e333feea",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^6.0",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^0.13",
+                "phpstan/phpstan-phpunit": "^0.11",
+                "phpstan/phpstan-shim": "^0.11",
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.com/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-29T17:27:14+00:00"
+        },
+        {
+            "name": "doctrine/lexer",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/lexer.git",
+                "reference": "e864bbf5904cb8f5bb334f99209b48018522f042"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/e864bbf5904cb8f5bb334f99209b48018522f042",
+                "reference": "e864bbf5904cb8f5bb334f99209b48018522f042",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^6.0",
+                "phpstan/phpstan": "^0.11.8",
+                "phpunit/phpunit": "^8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Lexer\\": "lib/Doctrine/Common/Lexer"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Lexer parser library that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "https://www.doctrine-project.org/projects/lexer.html",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "lexer",
+                "parser",
+                "php"
+            ],
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Flexer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-25T17:44:05+00:00"
+        },
+        {
+            "name": "doctrine/migrations",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/migrations.git",
+                "reference": "69eaf2ca5bc48357b43ddbdc31ccdffc0e2a0882"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/migrations/zipball/69eaf2ca5bc48357b43ddbdc31ccdffc0e2a0882",
+                "reference": "69eaf2ca5bc48357b43ddbdc31ccdffc0e2a0882",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/dbal": "^2.10",
+                "doctrine/event-manager": "^1.0",
+                "ocramius/package-versions": "^1.3",
+                "ocramius/proxy-manager": "^2.0.2",
+                "php": "^7.2",
+                "psr/log": "^1.1.3",
+                "symfony/console": "^3.4||^4.0||^5.0",
+                "symfony/stopwatch": "^3.4||^4.0||^5.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^7.0",
+                "doctrine/orm": "^2.6",
+                "doctrine/persistence": "^1.3||^2.0",
+                "doctrine/sql-formatter": "^1.0",
+                "ext-pdo_sqlite": "*",
+                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan-deprecation-rules": "^0.12",
+                "phpstan/phpstan-phpunit": "^0.12",
+                "phpstan/phpstan-strict-rules": "^0.12",
+                "phpstan/phpstan-symfony": "^0.12",
+                "phpunit/phpunit": "^8.4",
+                "symfony/process": "^3.4||^4.0||^5.0",
+                "symfony/yaml": "^3.4||^4.0||^5.0"
+            },
+            "suggest": {
+                "doctrine/sql-formatter": "Allows to generate formatted SQL with the diff command.",
+                "symfony/yaml": "Allows the use of yaml for migration configuration files."
+            },
+            "bin": [
+                "bin/doctrine-migrations"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Migrations\\": "lib/Doctrine/Migrations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Michael Simonson",
+                    "email": "contact@mikesimonson.com"
+                }
+            ],
+            "description": "PHP Doctrine Migrations project offer additional functionality on top of the database abstraction layer (DBAL) for versioning your database schema and easily deploying changes to it. It is a very easy to use and a powerful tool.",
+            "homepage": "https://www.doctrine-project.org/projects/migrations.html",
+            "keywords": [
+                "database",
+                "dbal",
+                "migrations",
+                "php"
+            ],
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fmigrations",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-06-21T08:55:42+00:00"
+        },
+        {
+            "name": "doctrine/orm",
+            "version": "v2.7.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/orm.git",
+                "reference": "d95e03ba660d50d785a9925f41927fef0ee553cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/orm/zipball/d95e03ba660d50d785a9925f41927fef0ee553cf",
+                "reference": "d95e03ba660d50d785a9925f41927fef0ee553cf",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "^1.8",
+                "doctrine/cache": "^1.9.1",
+                "doctrine/collections": "^1.5",
+                "doctrine/common": "^2.11 || ^3.0",
+                "doctrine/dbal": "^2.9.3",
+                "doctrine/event-manager": "^1.1",
+                "doctrine/inflector": "^1.0",
+                "doctrine/instantiator": "^1.3",
+                "doctrine/lexer": "^1.0",
+                "doctrine/persistence": "^1.3.3 || ^2.0",
+                "ext-pdo": "*",
+                "ocramius/package-versions": "^1.2",
+                "php": "^7.1",
+                "symfony/console": "^3.0|^4.0|^5.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^5.0",
+                "phpstan/phpstan": "^0.12.18",
+                "phpunit/phpunit": "^7.5",
+                "symfony/yaml": "^3.4|^4.0|^5.0",
+                "vimeo/psalm": "^3.11"
+            },
+            "suggest": {
+                "symfony/yaml": "If you want to use YAML Metadata Mapping Driver"
+            },
+            "bin": [
+                "bin/doctrine"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\ORM\\": "lib/Doctrine/ORM"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "Object-Relational-Mapper for PHP",
+            "homepage": "https://www.doctrine-project.org/projects/orm.html",
+            "keywords": [
+                "database",
+                "orm"
+            ],
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine/orm",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-26T16:03:49+00:00"
+        },
+        {
+            "name": "doctrine/persistence",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/persistence.git",
+                "reference": "1dee036f22cd5dc0bc12132f1d1c38415907be55"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/persistence/zipball/1dee036f22cd5dc0bc12132f1d1c38415907be55",
+                "reference": "1dee036f22cd5dc0bc12132f1d1c38415907be55",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "^1.0",
+                "doctrine/cache": "^1.0",
+                "doctrine/collections": "^1.0",
+                "doctrine/event-manager": "^1.0",
+                "doctrine/reflection": "^1.2",
+                "php": "^7.1"
+            },
+            "conflict": {
+                "doctrine/common": "<2.10@dev"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^6.0",
+                "phpstan/phpstan": "^0.11",
+                "phpunit/phpunit": "^7.0",
+                "vimeo/psalm": "^3.11"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\": "lib/Doctrine/Common",
+                    "Doctrine\\Persistence\\": "lib/Doctrine/Persistence"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "The Doctrine Persistence project is a set of shared interfaces and functionality that the different Doctrine object mappers share.",
+            "homepage": "https://doctrine-project.org/projects/persistence.html",
+            "keywords": [
+                "mapper",
+                "object",
+                "odm",
+                "orm",
+                "persistence"
+            ],
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fpersistence",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-12T19:32:44+00:00"
+        },
+        {
+            "name": "doctrine/reflection",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/reflection.git",
+                "reference": "55e71912dfcd824b2fdd16f2d9afe15684cfce79"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/reflection/zipball/55e71912dfcd824b2fdd16f2d9afe15684cfce79",
+                "reference": "55e71912dfcd824b2fdd16f2d9afe15684cfce79",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "^1.0",
+                "ext-tokenizer": "*",
+                "php": "^7.1"
+            },
+            "conflict": {
+                "doctrine/common": "<2.9"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^5.0",
+                "doctrine/common": "^2.10",
+                "phpstan/phpstan": "^0.11.0",
+                "phpstan/phpstan-phpunit": "^0.11.0",
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\": "lib/Doctrine/Common"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "The Doctrine Reflection project is a simple library used by the various Doctrine projects which adds some additional functionality on top of the reflection functionality that comes with PHP. It allows you to get the reflection information about classes, methods and properties statically.",
+            "homepage": "https://www.doctrine-project.org/projects/reflection.html",
+            "keywords": [
+                "reflection",
+                "static"
+            ],
+            "time": "2020-03-27T11:06:43+00:00"
+        },
+        {
+            "name": "doctrine/sql-formatter",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/sql-formatter.git",
+                "reference": "56070bebac6e77230ed7d306ad13528e60732871"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/sql-formatter/zipball/56070bebac6e77230ed7d306ad13528e60732871",
+                "reference": "56070bebac6e77230ed7d306ad13528e60732871",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.4"
+            },
+            "bin": [
+                "bin/sql-formatter"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\SqlFormatter\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jeremy Dorn",
+                    "email": "jeremy@jeremydorn.com",
+                    "homepage": "http://jeremydorn.com/"
+                }
+            ],
+            "description": "a PHP SQL highlighting library",
+            "homepage": "https://github.com/doctrine/sql-formatter/",
+            "keywords": [
+                "highlight",
+                "sql"
+            ],
+            "time": "2020-07-30T16:57:33+00:00"
+        },
         {
             "name": "greenter/core",
             "version": "v4.0.2",
@@ -299,6 +1746,185 @@
             "time": "2020-07-31T04:45:22+00:00"
         },
         {
+            "name": "laminas/laminas-code",
+            "version": "3.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-code.git",
+                "reference": "1cb8f203389ab1482bf89c0e70a04849bacd7766"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-code/zipball/1cb8f203389ab1482bf89c0e70a04849bacd7766",
+                "reference": "1cb8f203389ab1482bf89c0e70a04849bacd7766",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-eventmanager": "^2.6 || ^3.0",
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^7.1"
+            },
+            "conflict": {
+                "phpspec/prophecy": "<1.9.0"
+            },
+            "replace": {
+                "zendframework/zend-code": "self.version"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^1.7",
+                "ext-phar": "*",
+                "laminas/laminas-coding-standard": "^1.0",
+                "laminas/laminas-stdlib": "^2.7 || ^3.0",
+                "phpunit/phpunit": "^7.5.16 || ^8.4"
+            },
+            "suggest": {
+                "doctrine/annotations": "Doctrine\\Common\\Annotations >=1.0 for annotation features",
+                "laminas/laminas-stdlib": "Laminas\\Stdlib component"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4.x-dev",
+                    "dev-develop": "3.5.x-dev",
+                    "dev-dev-4.0": "4.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Code\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Extensions to the PHP Reflection API, static code scanning, and code generation",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "code",
+                "laminas"
+            ],
+            "time": "2019-12-31T16:28:24+00:00"
+        },
+        {
+            "name": "laminas/laminas-eventmanager",
+            "version": "3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-eventmanager.git",
+                "reference": "1940ccf30e058b2fd66f5a9d696f1b5e0027b082"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-eventmanager/zipball/1940ccf30e058b2fd66f5a9d696f1b5e0027b082",
+                "reference": "1940ccf30e058b2fd66f5a9d696f1b5e0027b082",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^7.3 || ^8.0"
+            },
+            "replace": {
+                "zendframework/zend-eventmanager": "^3.2.1"
+            },
+            "require-dev": {
+                "container-interop/container-interop": "^1.1",
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-stdlib": "^2.7.3 || ^3.0",
+                "phpbench/phpbench": "^0.17.1",
+                "phpunit/phpunit": "^8.5.8"
+            },
+            "suggest": {
+                "container-interop/container-interop": "^1.1, to use the lazy listeners feature",
+                "laminas/laminas-stdlib": "^2.7.3 || ^3.0, to use the FilterChain feature"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3.x-dev",
+                    "dev-develop": "3.4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\EventManager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Trigger and listen to events within a PHP application",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "event",
+                "eventmanager",
+                "events",
+                "laminas"
+            ],
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2020-08-25T11:10:44+00:00"
+        },
+        {
+            "name": "laminas/laminas-zendframework-bridge",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
+                "reference": "6ede70583e101030bcace4dcddd648f760ddf642"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/6ede70583e101030bcace4dcddd648f760ddf642",
+                "reference": "6ede70583e101030bcace4dcddd648f760ddf642",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.1 || ^9.3",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "module": "Laminas\\ZendFrameworkBridge"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/autoload.php"
+                ],
+                "psr-4": {
+                    "Laminas\\ZendFrameworkBridge\\": "src//"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Alias legacy ZF class names to Laminas Project equivalents.",
+            "keywords": [
+                "ZendFramework",
+                "autoloading",
+                "laminas",
+                "zf"
+            ],
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2020-09-14T14:23:00+00:00"
+        },
+        {
             "name": "monolog/monolog",
             "version": "2.1.1",
             "source": {
@@ -454,6 +2080,91 @@
                 "ziparchive"
             ],
             "time": "2020-07-11T21:01:42+00:00"
+        },
+        {
+            "name": "ocramius/proxy-manager",
+            "version": "2.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Ocramius/ProxyManager.git",
+                "reference": "ac1dd414fd114cfc0da9930e0ab46063c2f5e62a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Ocramius/ProxyManager/zipball/ac1dd414fd114cfc0da9930e0ab46063c2f5e62a",
+                "reference": "ac1dd414fd114cfc0da9930e0ab46063c2f5e62a",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-code": "^3.4.1",
+                "ocramius/package-versions": "^1.8.0",
+                "php": "~7.4.1",
+                "webimpress/safe-writer": "^2.0.1"
+            },
+            "conflict": {
+                "doctrine/annotations": "<1.6.1",
+                "laminas/laminas-stdlib": "<3.2.1",
+                "zendframework/zend-stdlib": "<3.2.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^6.0.0",
+                "ext-phar": "*",
+                "infection/infection": "^0.16.2",
+                "nikic/php-parser": "^4.4.0",
+                "phpbench/phpbench": "^0.17.0",
+                "phpunit/phpunit": "^9.1.1",
+                "slevomat/coding-standard": "^5.0.4",
+                "squizlabs/php_codesniffer": "^3.5.4",
+                "vimeo/psalm": "^3.11.1"
+            },
+            "suggest": {
+                "laminas/laminas-json": "To have the JsonRpc adapter (Remote Object feature)",
+                "laminas/laminas-soap": "To have the Soap adapter (Remote Object feature)",
+                "laminas/laminas-xmlrpc": "To have the XmlRpc adapter (Remote Object feature)",
+                "ocramius/generated-hydrator": "To have very fast object to array to object conversion for ghost objects"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "ProxyManager\\": "src/ProxyManager"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.io/"
+                }
+            ],
+            "description": "A library providing utilities to generate, instantiate and generally operate with Object Proxies",
+            "homepage": "https://github.com/Ocramius/ProxyManager",
+            "keywords": [
+                "aop",
+                "lazy loading",
+                "proxy",
+                "proxy pattern",
+                "service proxies"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/Ocramius",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/ocramius/proxy-manager",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-04-13T14:42:16+00:00"
         },
         {
             "name": "psr/cache",
@@ -1188,6 +2899,120 @@
                 }
             ],
             "time": "2020-06-06T08:49:21+00:00"
+        },
+        {
+            "name": "symfony/doctrine-bridge",
+            "version": "v5.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/doctrine-bridge.git",
+                "reference": "31cb4cfe6b9452cc1916022e995a08de4005299a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/doctrine-bridge/zipball/31cb4cfe6b9452cc1916022e995a08de4005299a",
+                "reference": "31cb4cfe6b9452cc1916022e995a08de4005299a",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/event-manager": "~1.0",
+                "doctrine/persistence": "^1.3|^2",
+                "php": ">=7.2.5",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php80": "^1.15",
+                "symfony/service-contracts": "^1.1|^2"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<5.4.3",
+                "symfony/dependency-injection": "<4.4",
+                "symfony/form": "<5.1",
+                "symfony/http-kernel": "<5",
+                "symfony/messenger": "<4.4",
+                "symfony/property-info": "<5",
+                "symfony/security-bundle": "<5",
+                "symfony/security-core": "<5",
+                "symfony/validator": "<5.0.2"
+            },
+            "require-dev": {
+                "composer/package-versions-deprecated": "^1.8",
+                "doctrine/annotations": "~1.7",
+                "doctrine/cache": "~1.6",
+                "doctrine/collections": "~1.0",
+                "doctrine/data-fixtures": "^1.1",
+                "doctrine/dbal": "~2.4|^3.0",
+                "doctrine/orm": "^2.6.3",
+                "doctrine/reflection": "~1.0",
+                "symfony/cache": "^5.1",
+                "symfony/config": "^4.4|^5.0",
+                "symfony/dependency-injection": "^4.4|^5.0",
+                "symfony/doctrine-messenger": "^5.1",
+                "symfony/expression-language": "^4.4|^5.0",
+                "symfony/form": "^5.1",
+                "symfony/http-kernel": "^5.0",
+                "symfony/messenger": "^4.4|^5.0",
+                "symfony/property-access": "^4.4|^5.0",
+                "symfony/property-info": "^5.0",
+                "symfony/proxy-manager-bridge": "^4.4|^5.0",
+                "symfony/security-core": "^5.0",
+                "symfony/stopwatch": "^4.4|^5.0",
+                "symfony/translation": "^4.4|^5.0",
+                "symfony/validator": "^5.0.2",
+                "symfony/var-dumper": "^4.4|^5.0"
+            },
+            "suggest": {
+                "doctrine/data-fixtures": "",
+                "doctrine/dbal": "",
+                "doctrine/orm": "",
+                "symfony/form": "",
+                "symfony/property-info": "",
+                "symfony/validator": ""
+            },
+            "type": "symfony-bridge",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bridge\\Doctrine\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Doctrine Bridge",
+            "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-08-21T17:19:47+00:00"
         },
         {
             "name": "symfony/dotenv",
@@ -2726,6 +4551,70 @@
             "time": "2020-07-06T13:23:11+00:00"
         },
         {
+            "name": "symfony/stopwatch",
+            "version": "v5.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/stopwatch.git",
+                "reference": "0f7c58cf81dbb5dd67d423a89d577524a2ec0323"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/0f7c58cf81dbb5dd67d423a89d577524a2ec0323",
+                "reference": "0f7c58cf81dbb5dd67d423a89d577524a2ec0323",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/service-contracts": "^1.0|^2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Stopwatch\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Stopwatch Component",
+            "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-20T17:43:50+00:00"
+        },
+        {
             "name": "symfony/string",
             "version": "v5.1.3",
             "source": {
@@ -3484,9 +5373,116 @@
                 }
             ],
             "time": "2020-08-05T15:13:19+00:00"
+        },
+        {
+            "name": "webimpress/safe-writer",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webimpress/safe-writer.git",
+                "reference": "5cfafdec5873c389036f14bf832a5efc9390dcdd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webimpress/safe-writer/zipball/5cfafdec5873c389036f14bf832a5efc9390dcdd",
+                "reference": "5cfafdec5873c389036f14bf832a5efc9390dcdd",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5.8 || ^9.3.7",
+                "vimeo/psalm": "^3.14.2",
+                "webimpress/coding-standard": "^1.1.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1.x-dev",
+                    "dev-develop": "2.2.x-dev",
+                    "dev-release-1.0": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webimpress\\SafeWriter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "description": "Tool to write files safely, to avoid race conditions",
+            "keywords": [
+                "concurrent write",
+                "file writer",
+                "race condition",
+                "safe writer",
+                "webimpress"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/michalbundyra",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-08-25T07:21:11+00:00"
         }
     ],
     "packages-dev": [
+        {
+            "name": "nikic/php-parser",
+            "version": "v4.9.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "88e519766fc58bd46b8265561fb79b54e2e00b28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/88e519766fc58bd46b8265561fb79b54e2e00b28",
+                "reference": "88e519766fc58bd46b8265561fb79b54e2e00b28",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "time": "2020-08-30T16:15:20+00:00"
+        },
         {
             "name": "phpstan/phpstan",
             "version": "0.12.42",
@@ -3542,6 +5538,89 @@
                 }
             ],
             "time": "2020-09-02T13:14:53+00:00"
+        },
+        {
+            "name": "symfony/maker-bundle",
+            "version": "v1.21.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/maker-bundle.git",
+                "reference": "da629093c7bf9abd9a6a0f232a43bbb1b88de68d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/maker-bundle/zipball/da629093c7bf9abd9a6a0f232a43bbb1b88de68d",
+                "reference": "da629093c7bf9abd9a6a0f232a43bbb1b88de68d",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/inflector": "^1.2",
+                "nikic/php-parser": "^4.0",
+                "php": "^7.1.3",
+                "symfony/config": "^3.4|^4.0|^5.0",
+                "symfony/console": "^3.4|^4.0|^5.0",
+                "symfony/dependency-injection": "^3.4|^4.0|^5.0",
+                "symfony/filesystem": "^3.4|^4.0|^5.0",
+                "symfony/finder": "^3.4|^4.0|^5.0",
+                "symfony/framework-bundle": "^3.4|^4.0|^5.0",
+                "symfony/http-kernel": "^3.4|^4.0|^5.0"
+            },
+            "require-dev": {
+                "composer/semver": "^3.0@dev",
+                "doctrine/doctrine-bundle": "^1.8|^2.0",
+                "doctrine/orm": "^2.3",
+                "friendsofphp/php-cs-fixer": "^2.8",
+                "friendsoftwig/twigcs": "^3.1.2",
+                "symfony/http-client": "^4.3|^5.0",
+                "symfony/phpunit-bridge": "^4.3|^5.0",
+                "symfony/process": "^3.4|^4.0|^5.0",
+                "symfony/security-core": "^3.4|^4.0|^5.0",
+                "symfony/yaml": "^3.4|^4.0|^5.0"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bundle\\MakerBundle\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Maker helps you create empty commands, controllers, form classes, tests and more so you can forget about writing boilerplate code.",
+            "homepage": "https://symfony.com/doc/current/bundles/SymfonyMakerBundle/index.html",
+            "keywords": [
+                "code generator",
+                "generator",
+                "scaffold",
+                "scaffolding"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-08-29T18:05:46+00:00"
         }
     ],
     "aliases": [],

--- a/composer/DoctrineMigrations.php
+++ b/composer/DoctrineMigrations.php
@@ -1,0 +1,19 @@
+<?php
+
+class DoctrineMigrations
+{
+    public static function run()
+    {
+        if (empty(getenv('CI'))) {
+            return;
+        }
+
+        $baseProject = __DIR__.'/../';
+        echo 'Create Database...'.PHP_EOL;
+        shell_exec('php '.$baseProject.'bin/console doctrine:database:create');
+        echo 'Run Database Migrations...'.PHP_EOL;
+        shell_exec('php '.$baseProject.'bin/console doctrine:migrations:migrate --no-interaction');
+    }
+}
+
+DoctrineMigrations::run();

--- a/composer/XsltDownloader.php
+++ b/composer/XsltDownloader.php
@@ -1,0 +1,41 @@
+<?php
+
+use PhpZip\ZipFile;
+
+require 'vendor/autoload.php';
+
+class XsltDownloader
+{
+    public static function run()
+    {
+        $xslZipUrl = getenv('XSLT_URL');
+        if (empty($xslZipUrl)) {
+            return;
+        }
+
+        $destPath = __DIR__.'/../var/xslt';
+        if (is_dir($destPath)) {
+            return;
+        }
+
+        echo 'Downloading XSLT files.'.PHP_EOL;
+        $zip = file_get_contents($xslZipUrl);
+
+        echo 'Downloaded XSLT files.'.PHP_EOL;
+        mkdir($destPath, 0777, true);
+
+        echo 'Save XSLT files on '.$destPath.PHP_EOL;
+        self::decompress($zip, $destPath);
+    }
+
+    private static function decompress($zip, $destination)
+    {
+        $zipFile = new ZipFile();
+        $zipFile->openFromString($zip)
+                ->extractTo($destination);
+
+        $zipFile->close();
+    }
+}
+
+XsltDownloader::run();

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -5,4 +5,7 @@ return [
     Symfony\Bundle\MonologBundle\MonologBundle::class => ['all' => true],
     Symfony\Bundle\TwigBundle\TwigBundle::class => ['all' => true],
     Twig\Extra\TwigExtraBundle\TwigExtraBundle::class => ['all' => true],
+    Doctrine\Bundle\DoctrineBundle\DoctrineBundle::class => ['all' => true],
+    Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle::class => ['all' => true],
+    Symfony\Bundle\MakerBundle\MakerBundle::class => ['dev' => true],
 ];

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -1,0 +1,18 @@
+doctrine:
+    dbal:
+        url: '%env(resolve:DATABASE_URL)%'
+
+        # IMPORTANT: You MUST configure your server version,
+        # either here or in the DATABASE_URL env var (see .env file)
+        #server_version: '5.7'
+    orm:
+        auto_generate_proxy_classes: true
+        naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware
+        auto_mapping: true
+        mappings:
+            App:
+                is_bundle: false
+                type: annotation
+                dir: '%kernel.project_dir%/src/Entity'
+                prefix: 'App\Entity'
+                alias: App

--- a/config/packages/doctrine_migrations.yaml
+++ b/config/packages/doctrine_migrations.yaml
@@ -1,0 +1,5 @@
+doctrine_migrations:
+    migrations_paths:
+        # namespace is arbitrary but should be different from App\Migrations
+        # as migrations classes should NOT be autoloaded
+        'DoctrineMigrations': '%kernel.project_dir%/migrations'

--- a/config/packages/prod/doctrine.yaml
+++ b/config/packages/prod/doctrine.yaml
@@ -1,0 +1,20 @@
+doctrine:
+    orm:
+        auto_generate_proxy_classes: false
+        metadata_cache_driver:
+            type: pool
+            pool: doctrine.system_cache_pool
+        query_cache_driver:
+            type: pool
+            pool: doctrine.system_cache_pool
+        result_cache_driver:
+            type: pool
+            pool: doctrine.result_cache_pool
+
+framework:
+    cache:
+        pools:
+            doctrine.result_cache_pool:
+                adapter: cache.app
+            doctrine.system_cache_pool:
+                adapter: cache.system

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -26,6 +26,7 @@ services:
             - '../src/DependencyInjection/'
             - '../src/Entity/'
             - '../src/Kernel.php'
+            - '../src/Model/'
             - '../src/Tests/'
 
     # controllers are imported separately to make sure services can be injected

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -5,12 +5,12 @@
 # https://symfony.com/doc/current/best_practices/configuration.html#application-related-configuration
 parameters:
     env(CERT_FILE): '%kernel.project_dir%/keys/cert.pfx'
+    app.ose_ruc: '20000000001'
     app.soap_user: '%env(SOAP_USER)%'
     app.soap_pass: '%env(SOAP_PASS)%'
     app.soap_wsdl: '%kernel.project_dir%/public/ol-ti-itcpe/billService.wsdl'
     app.sign_cert: '%env(file:CERT_FILE)%'
     app.sign_pass: '%env(SIGN_PASS)%'
-    app.ose_ruc: '20000000001'
     app.xsl_basepath: '%kernel.project_dir%/var/xslt/sunat_archivos/sfs/VALI/commons/xsl/validation'
 
 services:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -38,7 +38,7 @@ services:
     App\Handler\WsdlHandler:
         decorates: App\Handler\SoapServerHandler
 
-    App\Handler\RequestHandlerInterface: '@App\Handler\WsdlHandler'
+    App\Handler\RequestHandlerInterface: '@App\Handler\SoapServerHandler'
 
     App\Services\Bill\BillService:
         stack:
@@ -51,7 +51,7 @@ services:
     App\Services\Zip\XmlFilenameDecorator:
         decorates: App\Services\Zip\XmlZipFly
 
-    App\Services\Zip\XmlZipInterface: '@App\Services\Zip\XmlFilenameDecorator'
+    App\Services\Zip\XmlZipInterface: '@App\Services\Zip\XmlZipFly'
 
     App\Validator\XmlValidatorInterface:
         class: App\Validator\MultiValidator
@@ -61,8 +61,8 @@ services:
                 - '@App\Validator\XmlSignValidator'
                 - '@App\Validator\CpeXslValidator'
 
-    App\Services\Cdr\ZipCdrWriter:
-        decorates: App\Services\Cdr\XmlCdrWriter
+#    App\Services\Cdr\ZipCdrWriter:
+#        decorates: App\Services\Cdr\XmlCdrWriter
 
     App\Services\Cdr\XmlAppCdrCreator:
         arguments:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -11,6 +11,7 @@ parameters:
     app.sign_cert: '%env(file:CERT_FILE)%'
     app.sign_pass: '%env(SIGN_PASS)%'
     app.ose_ruc: '20000000001'
+    app.xsl_basepath: '%kernel.project_dir%/var/xslt/sunat_archivos/sfs/VALI/commons/xsl/validation'
 
 services:
     # default configuration for services in *this* file
@@ -97,4 +98,4 @@ services:
     Greenter\Validator\Resolver\RuleResolverInterface:
         class: Greenter\Validator\Resolver\XslPathResolver
         arguments:
-            $basePath: '%kernel.project_dir%/var/xslt/sunat_archivos/sfs/VALI/commons/xsl/validation'
+            $basePath: '%app.xsl_basepath%'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -64,7 +64,7 @@ services:
             - '%app.ose_ruc%'
 
     App\Services\Cdr\AppCdrCreatorInterface: '@App\Services\Cdr\XmlAppCdrCreator'
-    App\Services\Cdr\CdrWriterInterface: '@App\Services\Cdr\ZipCdrWriter'
+    App\Services\Cdr\CdrWriterInterface: '@App\Services\Cdr\XmlCdrWriter'
     App\Services\Cdr\CdrOutputInterface: '@App\Services\Cdr\CdrBridge'
 
     Greenter\XMLSecLibs\Sunat\SignedXml:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -71,6 +71,7 @@ services:
     App\Services\Cdr\AppCdrCreatorInterface: '@App\Services\Cdr\XmlAppCdrCreator'
     App\Services\Cdr\CdrWriterInterface: '@App\Services\Cdr\XmlCdrWriter'
     App\Services\Cdr\CdrOutputInterface: '@App\Services\Cdr\CdrBridge'
+    App\Services\Xml\XslDocResolverInterface: '@App\Services\Xml\FileSystemXslDocResolver'
 
     Greenter\XMLSecLibs\Sunat\SignedXml:
         factory: ['App\Factory\SignedXmlFactory', 'createSignedXml']
@@ -90,3 +91,10 @@ services:
     Greenter\Ws\Reader\FilenameExtractorInterface:
         class: Greenter\Ws\Reader\XmlFilenameExtractor
 
+    Greenter\Validator\Resolver\TypeResolverInterface:
+        class: Greenter\Validator\Resolver\XmlTypeResolver
+
+    Greenter\Validator\Resolver\RuleResolverInterface:
+        class: Greenter\Validator\Resolver\XslPathResolver
+        arguments:
+            $basePath: '%kernel.project_dir%/var/xslt/sunat_archivos/sfs/VALI/commons/xsl/validation'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -1,5 +1,5 @@
 # This file is the entry point to configure your own services.
-# Files in the packages/ subdirectory configure your dependencies.
+# File in the packages/ subdirectory configure your dependencies.
 
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices/configuration.html#application-related-configuration
@@ -12,6 +12,7 @@ parameters:
     app.sign_cert: '%env(file:CERT_FILE)%'
     app.sign_pass: '%env(SIGN_PASS)%'
     app.xsl_basepath: '%kernel.project_dir%/var/xslt/sunat_archivos/sfs/VALI/commons/xsl/validation'
+    app.upload_dir: '%kernel.project_dir%/cpe_files'
 
 services:
     # default configuration for services in *this* file

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -99,3 +99,9 @@ services:
         class: Greenter\Validator\Resolver\XslPathResolver
         arguments:
             $basePath: '%app.xsl_basepath%'
+
+
+    Greenter\Validator\Parser\ResultParserInterface:
+        class: Greenter\Validator\Parser\ErrorResultParser
+
+    Greenter\Validator\Xml\XslValidator: ~

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -40,8 +40,8 @@ services:
 
     App\Handler\RequestHandlerInterface: '@App\Handler\WsdlHandler'
 
-    App\Services\BillServiceInterface:
-        class: App\Services\BillService
+    App\Services\Bill\BillServiceInterface:
+        class: App\Services\Bill\BillService
 
     App\Services\Zip\XmlFilenameDecorator:
         decorates: App\Services\Zip\XmlZipFly

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -12,7 +12,7 @@ parameters:
     app.sign_cert: '%env(file:CERT_FILE)%'
     app.sign_pass: '%env(SIGN_PASS)%'
     app.xsl_basepath: '%kernel.project_dir%/var/xslt/sunat_archivos/sfs/VALI/commons/xsl/validation'
-    app.upload_dir: '%kernel.project_dir%/cpe_files'
+    app.upload_dir: '%kernel.project_dir%/var/cpe_files'
 
 services:
     # default configuration for services in *this* file

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -40,8 +40,13 @@ services:
 
     App\Handler\RequestHandlerInterface: '@App\Handler\WsdlHandler'
 
-    App\Services\Bill\BillServiceInterface:
-        class: App\Services\Bill\BillService
+    App\Services\Bill\BillService:
+        stack:
+            - App\Services\Bill\AllowTypesBillDecorator: ~
+            - App\Services\Bill\ZipFormatBillDecorator: ~
+            - App\Services\Bill\BillService: ~
+
+    App\Services\Bill\BillServiceInterface: '@App\Services\Bill\BillService'
 
     App\Services\Zip\XmlFilenameDecorator:
         decorates: App\Services\Zip\XmlZipFly

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -70,10 +70,15 @@ services:
         arguments:
             - '%app.ose_ruc%'
 
+    App\Services\File\SystemFileStore:
+        arguments:
+            - '%app.upload_dir%'
+
     App\Services\Cdr\AppCdrCreatorInterface: '@App\Services\Cdr\XmlAppCdrCreator'
     App\Services\Cdr\CdrWriterInterface: '@App\Services\Cdr\XmlCdrWriter'
     App\Services\Cdr\CdrOutputInterface: '@App\Services\Cdr\CdrBridge'
     App\Services\Xml\XslDocResolverInterface: '@App\Services\Xml\FileSystemXslDocResolver'
+    App\Services\File\FileStoreInterface: '@App\Services\File\SystemFileStore'
 
     Greenter\XMLSecLibs\Sunat\SignedXml:
         factory: ['App\Factory\SignedXmlFactory', 'createSignedXml']

--- a/migrations/Version20200915153736.php
+++ b/migrations/Version20200915153736.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20200915153736 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE cpe_document (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, name VARCHAR(64) NOT NULL, issuer VARCHAR(11) NOT NULL, state_code VARCHAR(16) DEFAULT NULL, hash_cpe VARCHAR(255) DEFAULT NULL, hash_cdr VARCHAR(255) DEFAULT NULL, ticket VARCHAR(64) DEFAULT NULL)');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP TABLE cpe_document');
+    }
+}

--- a/migrations/Version20200918000816.php
+++ b/migrations/Version20200918000816.php
@@ -10,7 +10,7 @@ use Doctrine\Migrations\AbstractMigration;
 /**
  * Auto-generated Migration: Please modify to your needs!
  */
-final class Version20200915153736 extends AbstractMigration
+final class Version20200918000816 extends AbstractMigration
 {
     public function getDescription() : string
     {
@@ -20,7 +20,8 @@ final class Version20200915153736 extends AbstractMigration
     public function up(Schema $schema) : void
     {
         // this up() migration is auto-generated, please modify it to your needs
-        $this->addSql('CREATE TABLE cpe_document (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, name VARCHAR(64) NOT NULL, issuer VARCHAR(11) NOT NULL, state_code VARCHAR(16) DEFAULT NULL, hash_cpe VARCHAR(255) DEFAULT NULL, hash_cdr VARCHAR(255) DEFAULT NULL, ticket VARCHAR(64) DEFAULT NULL)');
+        $this->addSql('CREATE TABLE cpe_document (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, name VARCHAR(64) NOT NULL, state_code VARCHAR(16) DEFAULT NULL, hash_cpe VARCHAR(255) DEFAULT NULL, hash_cdr VARCHAR(255) DEFAULT NULL, ticket VARCHAR(64) DEFAULT NULL, create_date DATETIME NOT NULL)');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_FD553EE85E237E06 ON cpe_document (name)');
     }
 
     public function down(Schema $schema) : void

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- https://phpunit.readthedocs.io/en/latest/configuration.html -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="bin/.phpunit/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="tests/bootstrap.php"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+        <server name="APP_ENV" value="test" force="true" />
+        <server name="SHELL_VERBOSITY" value="-1" />
+        <server name="SYMFONY_PHPUNIT_REMOVE" value="" />
+        <server name="SYMFONY_PHPUNIT_VERSION" value="7.5" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Project Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
+</phpunit>

--- a/src/Controller/BillServiceController.php
+++ b/src/Controller/BillServiceController.php
@@ -11,16 +11,8 @@ use Symfony\Component\HttpFoundation\Response;
 
 class BillServiceController extends AbstractController
 {
-    /**
-     * @var RequestHandlerInterface
-     */
-    private $handler;
+    private RequestHandlerInterface $handler;
 
-    /**
-     * BillServiceController constructor.
-     *
-     * @param RequestHandlerInterface $handler
-     */
     public function __construct(RequestHandlerInterface $handler)
     {
         $this->handler = $handler;

--- a/src/Entity/CpeDocument.php
+++ b/src/Entity/CpeDocument.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Entity;
 
 use App\Repository\CpeDocumentRepository;
+use DateTime;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -20,14 +21,9 @@ class CpeDocument
     private ?int $id;
 
     /**
-     * @ORM\Column(type="string", length=64)
+     * @ORM\Column(type="string", length=64, unique=true)
      */
     private ?string $name;
-
-    /**
-     * @ORM\Column(type="string", length=11)
-     */
-    private ?string $issuer;
 
     /**
      * @ORM\Column(type="string", length=16, nullable=true)
@@ -49,6 +45,11 @@ class CpeDocument
      */
     private ?string $ticket;
 
+    /**
+     * @ORM\Column(type="datetime")
+     */
+    private ?DateTime $createDate;
+
     public function getId(): ?int
     {
         return $this->id;
@@ -62,18 +63,6 @@ class CpeDocument
     public function setName(string $name): self
     {
         $this->name = $name;
-
-        return $this;
-    }
-
-    public function getIssuer(): ?string
-    {
-        return $this->issuer;
-    }
-
-    public function setIssuer(string $issuer): self
-    {
-        $this->issuer = $issuer;
 
         return $this;
     }
@@ -123,6 +112,17 @@ class CpeDocument
     {
         $this->ticket = $ticket;
 
+        return $this;
+    }
+
+    public function getCreateDate(): ?DateTime
+    {
+        return $this->createDate;
+    }
+
+    public function setCreateDate(?DateTime $createDate): CpeDocument
+    {
+        $this->createDate = $createDate;
         return $this;
     }
 }

--- a/src/Entity/CpeDocument.php
+++ b/src/Entity/CpeDocument.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Repository\CpeDocumentRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity(repositoryClass=CpeDocumentRepository::class)
+ */
+class CpeDocument
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private ?int $id;
+
+    /**
+     * @ORM\Column(type="string", length=64)
+     */
+    private ?string $name;
+
+    /**
+     * @ORM\Column(type="string", length=11)
+     */
+    private ?string $issuer;
+
+    /**
+     * @ORM\Column(type="string", length=16, nullable=true)
+     */
+    private ?string $stateCode;
+
+    /**
+     * @ORM\Column(type="string", length=255, nullable=true)
+     */
+    private ?string $hashCpe;
+
+    /**
+     * @ORM\Column(type="string", length=255, nullable=true)
+     */
+    private ?string $hashCdr;
+
+    /**
+     * @ORM\Column(type="string", length=64, nullable=true)
+     */
+    private ?string $ticket;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getIssuer(): ?string
+    {
+        return $this->issuer;
+    }
+
+    public function setIssuer(string $issuer): self
+    {
+        $this->issuer = $issuer;
+
+        return $this;
+    }
+
+    public function getStateCode(): ?string
+    {
+        return $this->stateCode;
+    }
+
+    public function setStateCode(?string $stateCode): self
+    {
+        $this->stateCode = $stateCode;
+
+        return $this;
+    }
+
+    public function getHashCpe(): ?string
+    {
+        return $this->hashCpe;
+    }
+
+    public function setHashCpe(?string $hashCpe): self
+    {
+        $this->hashCpe = $hashCpe;
+
+        return $this;
+    }
+
+    public function getHashCdr(): ?string
+    {
+        return $this->hashCdr;
+    }
+
+    public function setHashCdr(?string $hashCdr): self
+    {
+        $this->hashCdr = $hashCdr;
+
+        return $this;
+    }
+
+    public function getTicket(): ?string
+    {
+        return $this->ticket;
+    }
+
+    public function setTicket(?string $ticket): self
+    {
+        $this->ticket = $ticket;
+
+        return $this;
+    }
+}

--- a/src/Handler/WsdlHandler.php
+++ b/src/Handler/WsdlHandler.php
@@ -11,20 +11,11 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class WsdlHandler implements RequestHandlerInterface
 {
-    /**
-     * @var RequestHandlerInterface
-     */
-    private $next;
+    private RequestHandlerInterface $next;
 
-    /**
-     * @var UrlGeneratorInterface
-     */
-    private $router;
+    private UrlGeneratorInterface $router;
 
-    /**
-     * @var ParameterBagInterface
-     */
-    private $params;
+    private ParameterBagInterface $params;
 
     /**
      * WsdlHandler constructor.

--- a/src/Model/ApplicationResponse.php
+++ b/src/Model/ApplicationResponse.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Entity;
+namespace App\Model;
 
 use DateTimeInterface;
 

--- a/src/Model/CpeCdrResult.php
+++ b/src/Model/CpeCdrResult.php
@@ -8,13 +8,13 @@ use DateTime;
 
 class CpeCdrResult
 {
-    private ?DateTime $dateReceived;
+    private ?DateTime $dateReceived = null;
 
-    private ?string $codeResult;
+    private ?string $codeResult = null;
 
-    private ?array $notes;
+    private ?array $notes = null;
 
-    private ?string $ticket;
+    private ?string $ticket = null;
 
     /**
      * @return DateTime|null

--- a/src/Model/CpeCdrResult.php
+++ b/src/Model/CpeCdrResult.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Entity;
+namespace App\Model;
 
 use DateTime;
 

--- a/src/Model/CpeCdrResult.php
+++ b/src/Model/CpeCdrResult.php
@@ -14,6 +14,8 @@ class CpeCdrResult
 
     private ?array $notes;
 
+    private ?string $ticket;
+
     /**
      * @return DateTime|null
      */
@@ -65,6 +67,24 @@ class CpeCdrResult
     public function setNotes(?array $notes): CpeCdrResult
     {
         $this->notes = $notes;
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getTicket(): ?string
+    {
+        return $this->ticket;
+    }
+
+    /**
+     * @param string|null $ticket
+     * @return CpeCdrResult
+     */
+    public function setTicket(?string $ticket): CpeCdrResult
+    {
+        $this->ticket = $ticket;
         return $this;
     }
 }

--- a/src/Model/CpeCdrResult.php
+++ b/src/Model/CpeCdrResult.php
@@ -8,18 +8,11 @@ use DateTime;
 
 class CpeCdrResult
 {
-    /**
-     * @var DateTime|null
-     */
-    private $dateReceived;
-    /**
-     * @var string|null
-     */
-    private $codeResult;
-    /**
-     * @var array|null
-     */
-    private $notes;
+    private ?DateTime $dateReceived;
+
+    private ?string $codeResult;
+
+    private ?array $notes;
 
     /**
      * @return DateTime|null

--- a/src/Model/ErrorCodeList.php
+++ b/src/Model/ErrorCodeList.php
@@ -6,6 +6,7 @@ namespace App\Model;
 
 final class ErrorCodeList
 {
+    public const INVALID_USER = '0102';
     public const ZIP_INVALID_NAME = '0151';
     public const ZIP_EMPTY = '0155';
     public const ZIP_CORRUPTO = '0156';

--- a/src/Model/ErrorCodeList.php
+++ b/src/Model/ErrorCodeList.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Entity;
+namespace App\Model;
 
 final class ErrorCodeList
 {

--- a/src/Model/ErrorCodeList.php
+++ b/src/Model/ErrorCodeList.php
@@ -7,6 +7,7 @@ namespace App\Model;
 final class ErrorCodeList
 {
     public const INVALID_USER = '0102';
+    public const TICKET_NOTFOUND = '0127';
     public const ZIP_INVALID_NAME = '0151';
     public const ZIP_EMPTY = '0155';
     public const ZIP_CORRUPTO = '0156';

--- a/src/Model/ErrorCodeList.php
+++ b/src/Model/ErrorCodeList.php
@@ -15,6 +15,7 @@ final class ErrorCodeList
     public const ZIP_ERROR_UNZIP = '0250';
     public const XML_NO_RAIZ = '0300';
     public const XML_NO_SCHEMA_FILE = '0304';
+    public const XML_CANNOT_PROCESS = '0305';
     public const XML_NO_PARSE = '0306';
     public const XML_ALTERADO = '2334';
 }

--- a/src/Model/GetStatusCdrRequest.php
+++ b/src/Model/GetStatusCdrRequest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Entity;
+namespace App\Model;
 
 class GetStatusCdrRequest
 {

--- a/src/Model/GetStatusCdrResponse.php
+++ b/src/Model/GetStatusCdrResponse.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace App\Entity;
+namespace App\Model;
 
 class GetStatusCdrResponse
 {
     /**
      * @var StatusCdrResponse
      */
-    private $statusCdr;
+    public $statusCdr;
 }

--- a/src/Model/GetStatusCdrResponse.php
+++ b/src/Model/GetStatusCdrResponse.php
@@ -7,7 +7,12 @@ namespace App\Model;
 class GetStatusCdrResponse
 {
     /**
-     * @var StatusCdrResponse
+     * @var StatusCdrResponse|null
      */
-    public $statusCdr;
+    public ?StatusCdrResponse $statusCdr;
+
+    public function __construct()
+    {
+        $this->statusCdr = new StatusCdrResponse();
+    }
 }

--- a/src/Model/GetStatusRequest.php
+++ b/src/Model/GetStatusRequest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace App\Entity;
+namespace App\Model;
 
-class SendPackResponse
+class GetStatusRequest
 {
     /**
      * @var string

--- a/src/Model/GetStatusResponse.php
+++ b/src/Model/GetStatusResponse.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Entity;
+namespace App\Model;
 
 class GetStatusResponse
 {

--- a/src/Model/GetStatusResponse.php
+++ b/src/Model/GetStatusResponse.php
@@ -7,7 +7,12 @@ namespace App\Model;
 class GetStatusResponse
 {
     /**
-     * @var StatusResponse
+     * @var StatusResponse|null
      */
-    public $status;
+    public ?StatusResponse $status;
+
+    public function __construct()
+    {
+        $this->status = new StatusResponse();
+    }
 }

--- a/src/Model/MinimalDocInfo.php
+++ b/src/Model/MinimalDocInfo.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Entity;
+namespace App\Model;
 
 class MinimalDocInfo
 {

--- a/src/Model/SendBillRequest.php
+++ b/src/Model/SendBillRequest.php
@@ -2,16 +2,17 @@
 
 declare(strict_types=1);
 
-namespace App\Entity;
+namespace App\Model;
 
-class StatusResponse
+class SendBillRequest
 {
     /**
      * @var string
      */
-    public $content;
+    public $fileName;
+
     /**
      * @var string
      */
-    public $statusCode;
+    public $contentFile;
 }

--- a/src/Model/SendBillResponse.php
+++ b/src/Model/SendBillResponse.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Entity;
+namespace App\Model;
 
 class SendBillResponse
 {

--- a/src/Model/SendPackRequest.php
+++ b/src/Model/SendPackRequest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace App\Entity;
+namespace App\Model;
 
-class SendSummaryRequest
+class SendPackRequest
 {
     /**
      * @var string

--- a/src/Model/SendPackResponse.php
+++ b/src/Model/SendPackResponse.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace App\Entity;
+namespace App\Model;
 
-class SendSummaryResponse
+class SendPackResponse
 {
     /**
      * @var string

--- a/src/Model/SendSummaryRequest.php
+++ b/src/Model/SendSummaryRequest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace App\Entity;
+namespace App\Model;
 
-class SendPackRequest
+class SendSummaryRequest
 {
     /**
      * @var string

--- a/src/Model/SendSummaryResponse.php
+++ b/src/Model/SendSummaryResponse.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace App\Entity;
+namespace App\Model;
 
-class GetStatusRequest
+class SendSummaryResponse
 {
     /**
      * @var string

--- a/src/Model/SoapCredential.php
+++ b/src/Model/SoapCredential.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Entity;
+namespace App\Model;
 
 class SoapCredential
 {

--- a/src/Model/StatusCdrResponse.php
+++ b/src/Model/StatusCdrResponse.php
@@ -2,20 +2,20 @@
 
 declare(strict_types=1);
 
-namespace App\Entity;
+namespace App\Model;
 
 class StatusCdrResponse
 {
     /**
      * @var string
      */
-    private $content;
+    public $content;
     /**
      * @var string
      */
-    private $statusCode;
+    public $statusCode;
     /**
      * @var string
      */
-    private $statusMessage;
+    public $statusMessage;
 }

--- a/src/Model/StatusResponse.php
+++ b/src/Model/StatusResponse.php
@@ -2,17 +2,16 @@
 
 declare(strict_types=1);
 
-namespace App\Entity;
+namespace App\Model;
 
-class SendBillRequest
+class StatusResponse
 {
     /**
      * @var string
      */
-    public $fileName;
-
+    public $content;
     /**
      * @var string
      */
-    public $contentFile;
+    public $statusCode;
 }

--- a/src/Model/ValidationError.php
+++ b/src/Model/ValidationError.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Entity;
+namespace App\Model;
 
 class ValidationError
 {

--- a/src/Model/ValidationError.php
+++ b/src/Model/ValidationError.php
@@ -6,15 +6,9 @@ namespace App\Model;
 
 class ValidationError
 {
-    /**
-     * @var string
-     */
-    private $code;
+    private ?string $code;
 
-    /**
-     * @var string|null
-     */
-    private $detail;
+    private ?string $detail;
 
     /**
      * ValidationError constructor.
@@ -28,18 +22,18 @@ class ValidationError
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getCode(): string
+    public function getCode(): ?string
     {
         return $this->code;
     }
 
     /**
-     * @param string $code
+     * @param string|null $code
      * @return ValidationError
      */
-    public function setCode(string $code): self
+    public function setCode(?string $code): self
     {
         $this->code = $code;
         return $this;

--- a/src/Model/ValueResult.php
+++ b/src/Model/ValueResult.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Entity;
+namespace App\Model;
 
 class ValueResult
 {

--- a/src/Repository/CpeDocumentRepository.php
+++ b/src/Repository/CpeDocumentRepository.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\CpeDocument;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method CpeDocument|null find($id, $lockMode = null, $lockVersion = null)
+ * @method CpeDocument|null findOneBy(array $criteria, array $orderBy = null)
+ * @method CpeDocument[]    findAll()
+ * @method CpeDocument[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class CpeDocumentRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, CpeDocument::class);
+    }
+
+    // /**
+    //  * @return CpeDocument[] Returns an array of CpeDocument objects
+    //  */
+    /*
+    public function findByExampleField($value)
+    {
+        return $this->createQueryBuilder('c')
+            ->andWhere('c.exampleField = :val')
+            ->setParameter('val', $value)
+            ->orderBy('c.id', 'ASC')
+            ->setMaxResults(10)
+            ->getQuery()
+            ->getResult()
+        ;
+    }
+    */
+
+    /*
+    public function findOneBySomeField($value): ?CpeDocument
+    {
+        return $this->createQueryBuilder('c')
+            ->andWhere('c.exampleField = :val')
+            ->setParameter('val', $value)
+            ->getQuery()
+            ->getOneOrNullResult()
+        ;
+    }
+    */
+}

--- a/src/Repository/CpeDocumentRepository.php
+++ b/src/Repository/CpeDocumentRepository.php
@@ -21,32 +21,23 @@ class CpeDocumentRepository extends ServiceEntityRepository
         parent::__construct($registry, CpeDocument::class);
     }
 
-    // /**
-    //  * @return CpeDocument[] Returns an array of CpeDocument objects
-    //  */
-    /*
-    public function findByExampleField($value)
+    public function findOneByName(?string $name): ?CpeDocument
     {
         return $this->createQueryBuilder('c')
-            ->andWhere('c.exampleField = :val')
-            ->setParameter('val', $value)
-            ->orderBy('c.id', 'ASC')
-            ->setMaxResults(10)
-            ->getQuery()
-            ->getResult()
-        ;
-    }
-    */
-
-    /*
-    public function findOneBySomeField($value): ?CpeDocument
-    {
-        return $this->createQueryBuilder('c')
-            ->andWhere('c.exampleField = :val')
-            ->setParameter('val', $value)
+            ->andWhere('c.name = :val')
+            ->setParameter('val', $name)
             ->getQuery()
             ->getOneOrNullResult()
         ;
     }
-    */
+
+    public function findOneByTicket(?string $ticket): ?CpeDocument
+    {
+        return $this->createQueryBuilder('c')
+            ->andWhere('c.ticket = :val')
+            ->setParameter('val', $ticket)
+            ->getQuery()
+            ->getOneOrNullResult()
+        ;
+    }
 }

--- a/src/Services/AllowTypesServiceDecorator.php
+++ b/src/Services/AllowTypesServiceDecorator.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\Services;
+
+use App\Services\Soap\ExceptionCreator;
+use App\Validator\FilenameValidator;
+use App\Model\{ErrorCodeList,
+    GetStatusCdrRequest,
+    GetStatusCdrResponse,
+    GetStatusRequest,
+    GetStatusResponse,
+    SendBillRequest,
+    SendBillResponse,
+    SendPackRequest,
+    SendPackResponse,
+    SendSummaryRequest,
+    SendSummaryResponse,
+    ValidationError};
+use Greenter\Validator\Entity\DocumentType;
+
+class AllowTypesServiceDecorator implements BillServiceInterface
+{
+    private BillServiceInterface $service;
+
+    private FilenameValidator $typesValidator;
+
+    private ExceptionCreator $exceptionCreator;
+
+    /**
+     * AllowTypesServiceDecorator constructor.
+     *
+     * @param BillServiceInterface $service
+     * @param FilenameValidator $typesValidator
+     * @param ExceptionCreator $exceptionCreator
+     */
+    public function __construct(BillServiceInterface $service, FilenameValidator $typesValidator, ExceptionCreator $exceptionCreator)
+    {
+        $this->service = $service;
+        $this->typesValidator = $typesValidator;
+        $this->exceptionCreator = $exceptionCreator;
+    }
+
+    /**
+     * @param SendBillRequest $request
+     * @return SendBillResponse
+     */
+    public function sendBill(SendBillRequest $request): SendBillResponse
+    {
+        $allowedTypes = [
+            DocumentType::FACTURA,
+            DocumentType::BOLETA,
+            DocumentType::NOTA_CREDITO,
+            DocumentType::NOTA_DEBITO,
+            DocumentType::PERCEPCION,
+            DocumentType::RETENCION,
+            DocumentType::GUIA_REMISION,
+        ];
+        if (!$this->typesValidator->isAllow($request->fileName, $allowedTypes)) {
+            throw $this->exceptionCreator->fromValidation(
+                new ValidationError(ErrorCodeList::ZIP_INVALID_NAME)
+            );
+        }
+
+        return $this->service->sendBill($request);
+    }
+
+    /**
+     * @param SendSummaryRequest $request
+     * @return SendSummaryResponse
+     */
+    public function sendSummary(SendSummaryRequest $request): SendSummaryResponse
+    {
+        $allowedTypes = [
+            DocumentType::RESUMEN_DIARIO,
+            DocumentType::COMUNICACION_BAJA,
+            DocumentType::RESUMEN_REVERSION,
+        ];
+        if (!$this->typesValidator->isAllow($request->fileName, $allowedTypes)) {
+            throw $this->exceptionCreator->fromValidation(
+                new ValidationError(ErrorCodeList::ZIP_INVALID_NAME)
+            );
+        }
+
+        return $this->service->sendSummary($request);
+    }
+
+    /**
+     * @param GetStatusRequest $request
+     * @return GetStatusResponse
+     */
+    public function getStatus(GetStatusRequest $request): GetStatusResponse
+    {
+        return $this->service->getStatus($request);
+    }
+
+    /**
+     * @param SendPackRequest $request
+     * @return SendPackResponse
+     */
+    public function sendPack(SendPackRequest $request): SendPackResponse
+    {
+        return $this->service->sendPack($request);
+    }
+
+    /**
+     * @param GetStatusCdrRequest $request
+     * @return GetStatusCdrResponse
+     */
+    public function getStatusCdr(GetStatusCdrRequest $request): GetStatusCdrResponse
+    {
+        return $this->service->getStatusCdr($request);
+    }
+}

--- a/src/Services/AuthSoapService.php
+++ b/src/Services/AuthSoapService.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace App\Services;
 
-use App\Model\ErrorCodeList;
-use App\Model\GetStatusCdrRequest;
-use App\Model\GetStatusRequest;
-use App\Model\SendBillRequest;
-use App\Model\SendPackRequest;
-use App\Model\SendSummaryRequest;
-use App\Model\ValidationError;
+use App\Model\{
+    ErrorCodeList,
+    GetStatusCdrRequest,
+    GetStatusRequest,
+    SendBillRequest,
+    SendPackRequest,
+    SendSummaryRequest,
+    ValidationError,
+};
 use App\Services\Soap\ExceptionCreator;
 
 class AuthSoapService

--- a/src/Services/AuthSoapService.php
+++ b/src/Services/AuthSoapService.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace App\Services;
 
+use App\Model\ErrorCodeList;
 use App\Model\GetStatusCdrRequest;
 use App\Model\GetStatusRequest;
 use App\Model\SendBillRequest;
 use App\Model\SendPackRequest;
 use App\Model\SendSummaryRequest;
-use SoapFault;
+use App\Model\ValidationError;
+use App\Services\Soap\ExceptionCreator;
 
 class AuthSoapService
 {
@@ -29,22 +31,28 @@ class AuthSoapService
     private $credentialStore;
 
     /**
+     * @var ExceptionCreator
+     */
+    private $exceptionCretor;
+
+    /**
      * @var bool
      */
     private $isAuthenticated = false;
 
     /**
-     * SoapService constructor
-     *
+     * AuthSoapService constructor.
      * @param BillServiceInterface $billService
      * @param Mapper $mapper
      * @param CredentialStore $credentialStore
+     * @param ExceptionCreator $exceptionCretor
      */
-    public function __construct(BillServiceInterface $billService, Mapper $mapper, CredentialStore $credentialStore)
+    public function __construct(BillServiceInterface $billService, Mapper $mapper, CredentialStore $credentialStore, ExceptionCreator $exceptionCretor)
     {
         $this->billService = $billService;
         $this->mapper = $mapper;
         $this->credentialStore = $credentialStore;
+        $this->exceptionCretor = $exceptionCretor;
     }
 
     /**
@@ -107,7 +115,7 @@ class AuthSoapService
     private function ensureAuthenticated()
     {
         if (!$this->isAuthenticated) {
-            throw new SoapFault("0102", "Usuario o contraseña incorrectos");
+            throw $this->exceptionCretor->fromValidation(new ValidationError(ErrorCodeList::INVALID_USER));
         }
     }
 }

--- a/src/Services/AuthSoapService.php
+++ b/src/Services/AuthSoapService.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace App\Services;
 
-use App\Entity\GetStatusCdrRequest;
-use App\Entity\GetStatusRequest;
-use App\Entity\SendBillRequest;
-use App\Entity\SendPackRequest;
-use App\Entity\SendSummaryRequest;
+use App\Model\GetStatusCdrRequest;
+use App\Model\GetStatusRequest;
+use App\Model\SendBillRequest;
+use App\Model\SendPackRequest;
+use App\Model\SendSummaryRequest;
 use SoapFault;
 
 class AuthSoapService

--- a/src/Services/AuthSoapService.php
+++ b/src/Services/AuthSoapService.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Services;
 
+use App\Services\Bill\BillServiceInterface;
+use App\Services\Util\Mapper;
 use App\Model\{
     ErrorCodeList,
     GetStatusCdrRequest,
@@ -17,30 +19,15 @@ use App\Services\Soap\ExceptionCreator;
 
 class AuthSoapService
 {
-    /**
-     * @var BillServiceInterface
-     */
-    private $billService;
+    private BillServiceInterface $billService;
 
-    /**
-     * @var Mapper
-     */
-    private $mapper;
+    private Mapper $mapper;
 
-    /**
-     * @var CredentialStore
-     */
-    private $credentialStore;
+    private CredentialStore $credentialStore;
 
-    /**
-     * @var ExceptionCreator
-     */
-    private $exceptionCretor;
+    private ExceptionCreator $exceptionCretor;
 
-    /**
-     * @var bool
-     */
-    private $isAuthenticated = false;
+    private bool $isAuthenticated = false;
 
     /**
      * AuthSoapService constructor.

--- a/src/Services/Bill/AllowTypesBillDecorator.php
+++ b/src/Services/Bill/AllowTypesBillDecorator.php
@@ -18,7 +18,7 @@ use App\Model\{ErrorCodeList,
     ValidationError};
 use Greenter\Validator\Entity\DocumentType;
 
-class AllowTypesServiceDecorator implements BillServiceInterface
+class AllowTypesBillDecorator implements BillServiceInterface
 {
     private BillServiceInterface $service;
 
@@ -27,7 +27,7 @@ class AllowTypesServiceDecorator implements BillServiceInterface
     private ExceptionCreator $exceptionCreator;
 
     /**
-     * AllowTypesServiceDecorator constructor.
+     * AllowTypesBillDecorator constructor.
      *
      * @param BillServiceInterface $service
      * @param FilenameValidator $typesValidator

--- a/src/Services/Bill/AllowTypesServiceDecorator.php
+++ b/src/Services/Bill/AllowTypesServiceDecorator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Services;
+namespace App\Services\Bill;
 
 use App\Services\Soap\ExceptionCreator;
 use App\Validator\FilenameValidator;

--- a/src/Services/Bill/BillService.php
+++ b/src/Services/Bill/BillService.php
@@ -73,7 +73,6 @@ class BillService implements BillServiceInterface
             ->setDateReceived($dateReceived)
             ->setCodeResult($error !== null ? $error->getCode() : '0')
             ->setNotes($error !== null ? [$error->getCode().'-'.$error->getDetail()] : [])
-            ->setTicket(null)
         ;
 
         $response = new SendBillResponse();

--- a/src/Services/Bill/BillService.php
+++ b/src/Services/Bill/BillService.php
@@ -6,6 +6,7 @@ namespace App\Services\Bill;
 
 use App\Repository\CpeDocumentRepository;
 use App\Services\Cdr\CdrOutputInterface;
+use App\Services\File\FileStoreInterface;
 use App\Services\Soap\ExceptionCreator;
 use App\Validator\XmlValidatorInterface;
 use App\Model\{CpeCdrResult,
@@ -34,19 +35,23 @@ class BillService implements BillServiceInterface
 
     private CpeDocumentRepository $repository;
 
+    private FileStoreInterface $fileStore;
+
     /**
      * BillService constructor.
      * @param XmlValidatorInterface $xmlValidator
      * @param ExceptionCreator $exceptionCreator
      * @param CdrOutputInterface $cdrOut
      * @param CpeDocumentRepository $repository
+     * @param FileStoreInterface $fileStore
      */
-    public function __construct(XmlValidatorInterface $xmlValidator, ExceptionCreator $exceptionCreator, CdrOutputInterface $cdrOut, CpeDocumentRepository $repository)
+    public function __construct(XmlValidatorInterface $xmlValidator, ExceptionCreator $exceptionCreator, CdrOutputInterface $cdrOut, CpeDocumentRepository $repository, FileStoreInterface $fileStore)
     {
         $this->xmlValidator = $xmlValidator;
         $this->exceptionCreator = $exceptionCreator;
         $this->cdrOut = $cdrOut;
         $this->repository = $repository;
+        $this->fileStore = $fileStore;
     }
 
     public function sendBill(SendBillRequest $request): SendBillResponse
@@ -110,7 +115,7 @@ class BillService implements BillServiceInterface
         }
 
         $obj = new GetStatusResponse();
-        $obj->status->content = file_get_contents('R-'.$cpe->getName().'.xml');
+        $obj->status->content = $this->fileStore->get('R-'.$cpe->getName().'.xml');
         $obj->status->statusCode = '0';
 
         return $obj;
@@ -137,7 +142,7 @@ class BillService implements BillServiceInterface
         $obj = new GetStatusCdrResponse();
         $obj->statusCdr->statusCode = '0';
         $obj->statusCdr->statusMessage = 'La constancia existe';
-        $obj->statusCdr->content = file_get_contents('R-'.$cpe->getName().'.xml');
+        $obj->statusCdr->content = $this->fileStore->get('R-'.$cpe->getName().'.xml');
 
         return $obj;
     }

--- a/src/Services/Bill/BillService.php
+++ b/src/Services/Bill/BillService.php
@@ -71,7 +71,7 @@ class BillService implements BillServiceInterface
         $cdrResult = (new CpeCdrResult())
             ->setDateReceived($dateReceived)
             ->setCodeResult($error !== null ? $error->getCode() : '0')
-            ->setNotes([]);
+            ->setNotes([$error->getCode().'-'.$error->getDetail()]);
 
         $obj = new SendBillResponse();
         $obj->applicationResponse = $this->cdrOut->output($doc, $cdrResult);

--- a/src/Services/Bill/BillService.php
+++ b/src/Services/Bill/BillService.php
@@ -73,10 +73,10 @@ class BillService implements BillServiceInterface
             ->setTicket(null)
         ;
 
-        $obj = new SendBillResponse();
-        $obj->applicationResponse = $this->cdrOut->output($doc, $cdrResult);
+        $response = new SendBillResponse();
+        $response->applicationResponse = $this->cdrOut->output($doc, $cdrResult);
 
-        return $obj;
+        return $response;
     }
 
     public function sendSummary(SendSummaryRequest $request): SendSummaryResponse
@@ -99,10 +99,10 @@ class BillService implements BillServiceInterface
         ;
         $this->cdrOut->output($doc, $cdrResult);
 
-        $obj = new SendSummaryResponse();
-        $obj->ticket = $ticket;
+        $response = new SendSummaryResponse();
+        $response->ticket = $ticket;
 
-        return $obj;
+        return $response;
     }
 
     public function getStatus(GetStatusRequest $request): GetStatusResponse
@@ -114,11 +114,11 @@ class BillService implements BillServiceInterface
             throw $this->exceptionCreator->fromCode(ErrorCodeList::TICKET_NOTFOUND);
         }
 
-        $obj = new GetStatusResponse();
-        $obj->status->content = $this->fileStore->get('R-'.$cpe->getName().'.xml');
-        $obj->status->statusCode = '0';
+        $response = new GetStatusResponse();
+        $response->status->content = $this->fileStore->get('R-'.$cpe->getName().'.xml');
+        $response->status->statusCode = '0';
 
-        return $obj;
+        return $response;
     }
 
     public function sendPack(SendPackRequest $request): SendPackResponse
@@ -139,11 +139,11 @@ class BillService implements BillServiceInterface
         if ($cpe === null) {
             throw $this->exceptionCreator->fromCode(ErrorCodeList::TICKET_NOTFOUND);
         }
-        $obj = new GetStatusCdrResponse();
-        $obj->statusCdr->statusCode = '0';
-        $obj->statusCdr->statusMessage = 'La constancia existe';
-        $obj->statusCdr->content = $this->fileStore->get('R-'.$cpe->getName().'.xml');
+        $response = new GetStatusCdrResponse();
+        $response->statusCdr->statusCode = '0';
+        $response->statusCdr->statusMessage = 'La constancia existe';
+        $response->statusCdr->content = $this->fileStore->get('R-'.$cpe->getName().'.xml');
 
-        return $obj;
+        return $response;
     }
 }

--- a/src/Services/Bill/BillService.php
+++ b/src/Services/Bill/BillService.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Services;
+namespace App\Services\Bill;
 
 use App\Services\Cdr\CdrOutputInterface;
 use App\Services\Soap\ExceptionCreator;

--- a/src/Services/Bill/BillService.php
+++ b/src/Services/Bill/BillService.php
@@ -71,7 +71,7 @@ class BillService implements BillServiceInterface
         $cdrResult = (new CpeCdrResult())
             ->setDateReceived($dateReceived)
             ->setCodeResult($error !== null ? $error->getCode() : '0')
-            ->setNotes([$error->getCode().'-'.$error->getDetail()]);
+            ->setNotes($error !== null ? [$error->getCode().'-'.$error->getDetail()] : []);
 
         $obj = new SendBillResponse();
         $obj->applicationResponse = $this->cdrOut->output($doc, $cdrResult);

--- a/src/Services/Bill/BillService.php
+++ b/src/Services/Bill/BillService.php
@@ -54,6 +54,9 @@ class BillService implements BillServiceInterface
         $this->fileStore = $fileStore;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function sendBill(SendBillRequest $request): SendBillResponse
     {
         $dateReceived = new DateTime();
@@ -79,6 +82,9 @@ class BillService implements BillServiceInterface
         return $response;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function sendSummary(SendSummaryRequest $request): SendSummaryResponse
     {
         $dateReceived = new DateTime();
@@ -105,6 +111,9 @@ class BillService implements BillServiceInterface
         return $response;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function getStatus(GetStatusRequest $request): GetStatusResponse
     {
         $ticket = $request->ticket;
@@ -121,11 +130,17 @@ class BillService implements BillServiceInterface
         return $response;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function sendPack(SendPackRequest $request): SendPackResponse
     {
         throw $this->exceptionCreator->fromCode(ErrorCodeList::XML_CANNOT_PROCESS);
     }
 
+    /**
+     * @inheritDoc
+     */
     public function getStatusCdr(GetStatusCdrRequest $request): GetStatusCdrResponse
     {
         $name = implode('-', [

--- a/src/Services/Bill/BillService.php
+++ b/src/Services/Bill/BillService.php
@@ -135,8 +135,8 @@ class BillService implements BillServiceInterface
             throw $this->exceptionCreator->fromCode(ErrorCodeList::TICKET_NOTFOUND);
         }
         $obj = new GetStatusCdrResponse();
-        $obj->statusCdr->statusCode = $cpe->getStateCode();
-        $obj->statusCdr->statusMessage = $cpe->getStateCode() === '0' ? 'ACEPTADO' : 'RECHAZADO';
+        $obj->statusCdr->statusCode = '0';
+        $obj->statusCdr->statusMessage = 'La constancia existe';
         $obj->statusCdr->content = file_get_contents('R-'.$cpe->getName().'.xml');
 
         return $obj;

--- a/src/Services/Bill/BillService.php
+++ b/src/Services/Bill/BillService.php
@@ -60,13 +60,8 @@ class BillService implements BillServiceInterface
     {
         $dateReceived = new DateTime();
 
-        $result = $this->zipReader->decompress($request->contentFile, $request->fileName);
-        if ($result->getError() !== null) {
-            throw $this->exceptionCreator->fromValidation($result->getError());
-        }
-
         $doc = new DOMDocument();
-        $doc->loadXML($result->getContent());
+        $doc->loadXML($request->contentFile);
 
         $error = $this->xmlValidator->validate($request->fileName, $doc);
         if ($error !== null && (int)$error->getCode() < 2000) {
@@ -86,14 +81,8 @@ class BillService implements BillServiceInterface
 
     public function sendSummary(SendSummaryRequest $request): SendSummaryResponse
     {
-
-        $result = $this->zipReader->decompress($request->contentFile, $request->fileName);
-        if ($result->getError() !== null) {
-            throw $this->exceptionCreator->fromValidation($result->getError());
-        }
-
         $doc = new DOMDocument();
-        $doc->loadXML($result->getContent());
+        $doc->loadXML($request->contentFile);
 
         $error = $this->xmlValidator->validate($request->fileName, $doc);
         if ($error !== null && (int)$error->getCode() < 2000) {

--- a/src/Services/Bill/BillService.php
+++ b/src/Services/Bill/BillService.php
@@ -23,7 +23,6 @@ use App\Model\{CpeCdrResult,
 };
 use DateTime;
 use DOMDocument;
-use SoapFault;
 
 class BillService implements BillServiceInterface
 {
@@ -119,7 +118,7 @@ class BillService implements BillServiceInterface
 
     public function sendPack(SendPackRequest $request): SendPackResponse
     {
-        throw new SoapFault('0000', 'NO IMPLEMENTADO');
+        throw $this->exceptionCreator->fromCode(ErrorCodeList::XML_CANNOT_PROCESS);
     }
 
     public function getStatusCdr(GetStatusCdrRequest $request): GetStatusCdrResponse

--- a/src/Services/Bill/BillServiceInterface.php
+++ b/src/Services/Bill/BillServiceInterface.php
@@ -16,16 +16,42 @@ use App\Model\{
     SendSummaryRequest,
     SendSummaryResponse,
 };
+use SoapFault;
 
 interface BillServiceInterface
 {
+    /**
+     * @param SendBillRequest $request
+     * @return SendBillResponse
+     * @throws SoapFault
+     */
     public function sendBill(SendBillRequest $request): SendBillResponse;
 
+    /**
+     * @param SendSummaryRequest $request
+     * @return SendSummaryResponse
+     * @throws SoapFault
+     */
     public function sendSummary(SendSummaryRequest $request): SendSummaryResponse;
 
+    /**
+     * @param GetStatusRequest $request
+     * @return GetStatusResponse
+     * @throws SoapFault
+     */
     public function getStatus(GetStatusRequest $request): GetStatusResponse;
 
+    /**
+     * @param SendPackRequest $request
+     * @return SendPackResponse
+     * @throws SoapFault
+     */
     public function sendPack(SendPackRequest $request): SendPackResponse;
 
+    /**
+     * @param GetStatusCdrRequest $request
+     * @return GetStatusCdrResponse
+     * @throws SoapFault
+     */
     public function getStatusCdr(GetStatusCdrRequest $request): GetStatusCdrResponse;
 }

--- a/src/Services/Bill/BillServiceInterface.php
+++ b/src/Services/Bill/BillServiceInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Services;
+namespace App\Services\Bill;
 
 use App\Model\{
     GetStatusCdrRequest,

--- a/src/Services/Bill/ZipFormatBillDecorator.php
+++ b/src/Services/Bill/ZipFormatBillDecorator.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Bill;
+
+use App\Model\GetStatusCdrRequest;
+use App\Model\GetStatusCdrResponse;
+use App\Model\GetStatusRequest;
+use App\Model\GetStatusResponse;
+use App\Model\SendBillRequest;
+use App\Model\SendBillResponse;
+use App\Model\SendPackRequest;
+use App\Model\SendPackResponse;
+use App\Model\SendSummaryRequest;
+use App\Model\SendSummaryResponse;
+use App\Services\Soap\ExceptionCreator;
+use App\Services\Zip\XmlZipInterface;
+use Greenter\Ws\Reader\FilenameExtractorInterface;
+
+class ZipFormatBillDecorator implements BillServiceInterface
+{
+    private BillServiceInterface $service;
+
+    private XmlZipInterface $zipper;
+
+    private FilenameExtractorInterface $filenameResolver;
+
+    private ExceptionCreator $exceptionCreator;
+
+    /**
+     * ZipFormatBillDecorator constructor.
+     *
+     * @param BillServiceInterface $service
+     * @param XmlZipInterface $zipper
+     * @param FilenameExtractorInterface $filenameResolver
+     * @param ExceptionCreator $exceptionCreator
+     */
+    public function __construct(BillServiceInterface $service, XmlZipInterface $zipper, FilenameExtractorInterface $filenameResolver, ExceptionCreator $exceptionCreator)
+    {
+        $this->service = $service;
+        $this->zipper = $zipper;
+        $this->filenameResolver = $filenameResolver;
+        $this->exceptionCreator = $exceptionCreator;
+    }
+
+    /**
+     * @param SendBillRequest $request
+     * @return SendBillResponse
+     */
+    public function sendBill(SendBillRequest $request): SendBillResponse
+    {
+        $result = $this->zipper->decompress($request->contentFile, $request->fileName);
+        if ($result->getError() !== null) {
+            throw $this->exceptionCreator->fromValidation($result->getError());
+        }
+
+        $request->contentFile = $result->getContent();
+        $response = $this->service->sendBill($request);
+
+        $response->applicationResponse = $this->zipper->compress('R-'.$request->fileName, $response->applicationResponse);
+
+        return $response;
+    }
+
+    /**
+     * @param SendSummaryRequest $request
+     * @return SendSummaryResponse
+     */
+    public function sendSummary(SendSummaryRequest $request): SendSummaryResponse
+    {
+        $result = $this->zipper->decompress($request->contentFile, $request->fileName);
+        if ($result->getError() !== null) {
+            throw $this->exceptionCreator->fromValidation($result->getError());
+        }
+
+        $request->contentFile = $result->getContent();
+        return $this->service->sendSummary($request);
+    }
+
+    /**
+     * @param GetStatusRequest $request
+     * @return GetStatusResponse
+     */
+    public function getStatus(GetStatusRequest $request): GetStatusResponse
+    {
+        $response = $this->service->getStatus($request);
+
+        $xmlContent = $response->status->content;
+        if ($xmlContent !== null) {
+            $name = $this->filenameResolver->getFilename($xmlContent);
+            $response->status->content = $this->zipper->compress('R-'.$name.'.zip', $xmlContent);
+        }
+
+        return $response;
+    }
+
+    /**
+     * @param SendPackRequest $request
+     * @return SendPackResponse
+     */
+    public function sendPack(SendPackRequest $request): SendPackResponse
+    {
+        return $this->service->sendPack($request);
+    }
+
+    /**
+     * @param GetStatusCdrRequest $request
+     * @return GetStatusCdrResponse
+     */
+    public function getStatusCdr(GetStatusCdrRequest $request): GetStatusCdrResponse
+    {
+        $response = $this->service->getStatusCdr($request);
+        $xmlContent = $response->statusCdr->content;
+        if ($xmlContent !== null) {
+            $name = $this->filenameResolver->getFilename($xmlContent);
+            $response->statusCdr->content = $this->zipper->compress('R-'.$name.'.zip', $xmlContent);
+        }
+
+        return $response;
+    }
+}

--- a/src/Services/Bill/ZipFormatBillDecorator.php
+++ b/src/Services/Bill/ZipFormatBillDecorator.php
@@ -58,7 +58,7 @@ class ZipFormatBillDecorator implements BillServiceInterface
         $request->contentFile = $result->getContent();
         $response = $this->service->sendBill($request);
 
-        $response->applicationResponse = $this->zipper->compress('R-'.$request->fileName, $response->applicationResponse);
+        $response->applicationResponse = $this->zipper->compress('R-'.$request->fileName, $response->applicationResponse)->getContent();
 
         return $response;
     }
@@ -89,7 +89,7 @@ class ZipFormatBillDecorator implements BillServiceInterface
         $xmlContent = $response->status->content;
         if ($xmlContent !== null) {
             $name = $this->filenameResolver->getFilename($xmlContent);
-            $response->status->content = $this->zipper->compress('R-'.$name.'.zip', $xmlContent);
+            $response->status->content = $this->zipper->compress('R-'.$name.'.zip', $xmlContent)->getContent();
         }
 
         return $response;
@@ -114,7 +114,7 @@ class ZipFormatBillDecorator implements BillServiceInterface
         $xmlContent = $response->statusCdr->content;
         if ($xmlContent !== null) {
             $name = $this->filenameResolver->getFilename($xmlContent);
-            $response->statusCdr->content = $this->zipper->compress('R-'.$name.'.zip', $xmlContent);
+            $response->statusCdr->content = $this->zipper->compress('R-'.$name.'.zip', $xmlContent)->getContent();
         }
 
         return $response;

--- a/src/Services/BillService.php
+++ b/src/Services/BillService.php
@@ -9,7 +9,8 @@ use App\Services\Soap\ExceptionCreator;
 use App\Services\Zip\XmlZipInterface;
 use App\Validator\FilenameValidator;
 use App\Validator\XmlValidatorInterface;
-use App\Entity\{CpeCdrResult,
+use App\Model\{
+    CpeCdrResult,
     ErrorCodeList,
     GetStatusCdrRequest,
     GetStatusCdrResponse,
@@ -22,7 +23,8 @@ use App\Entity\{CpeCdrResult,
     SendSummaryRequest,
     SendSummaryResponse,
     StatusResponse,
-    ValidationError};
+    ValidationError
+};
 use DateTime;
 use DOMDocument;
 use Greenter\Validator\Entity\DocumentType;
@@ -129,6 +131,11 @@ class BillService implements BillServiceInterface
             DocumentType::COMUNICACION_BAJA,
             DocumentType::RESUMEN_REVERSION,
         ];
+        if (!$this->typesValidator->isAllow($request->fileName, $allowedTypes)) {
+            throw $this->exceptionCreator->fromValidation(
+                new ValidationError(ErrorCodeList::ZIP_INVALID_NAME)
+            );
+        }
 
         $result = $this->zipReader->decompress($request->contentFile, $request->fileName);
         if ($result->getError() !== null) {

--- a/src/Services/BillServiceInterface.php
+++ b/src/Services/BillServiceInterface.php
@@ -4,16 +4,18 @@ declare(strict_types=1);
 
 namespace App\Services;
 
-use App\Entity\GetStatusCdrRequest;
-use App\Entity\GetStatusCdrResponse;
-use App\Entity\GetStatusRequest;
-use App\Entity\GetStatusResponse;
-use App\Entity\SendBillRequest;
-use App\Entity\SendBillResponse;
-use App\Entity\SendPackRequest;
-use App\Entity\SendPackResponse;
-use App\Entity\SendSummaryRequest;
-use App\Entity\SendSummaryResponse;
+use App\Model\{
+    GetStatusCdrRequest,
+    GetStatusCdrResponse,
+    GetStatusRequest,
+    GetStatusResponse,
+    SendBillRequest,
+    SendBillResponse,
+    SendPackRequest,
+    SendPackResponse,
+    SendSummaryRequest,
+    SendSummaryResponse,
+};
 
 interface BillServiceInterface
 {

--- a/src/Services/Cdr/AppCdrCreatorInterface.php
+++ b/src/Services/Cdr/AppCdrCreatorInterface.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace App\Services\Cdr;
 
-use App\Entity\ApplicationResponse;
-use App\Entity\CpeCdrResult;
+use App\Model\ApplicationResponse;
+use App\Model\CpeCdrResult;
 use DOMDocument;
 
 interface AppCdrCreatorInterface

--- a/src/Services/Cdr/CdrBridge.php
+++ b/src/Services/Cdr/CdrBridge.php
@@ -26,18 +26,19 @@ class CdrBridge implements CdrOutputInterface
 
     /**
      * CdrBridge constructor.
-     *
      * @param AppCdrCreatorInterface $appCdrCreator
      * @param CdrWriterInterface $cdrWriter
      * @param HashExtract $hashExtractor
      * @param EntityManagerInterface $repository
+     * @param FileStoreInterface $fileStore
      */
-    public function __construct(AppCdrCreatorInterface $appCdrCreator, CdrWriterInterface $cdrWriter, HashExtract $hashExtractor, EntityManagerInterface $repository)
+    public function __construct(AppCdrCreatorInterface $appCdrCreator, CdrWriterInterface $cdrWriter, HashExtract $hashExtractor, EntityManagerInterface $repository, FileStoreInterface $fileStore)
     {
         $this->appCdrCreator = $appCdrCreator;
         $this->cdrWriter = $cdrWriter;
         $this->hashExtractor = $hashExtractor;
         $this->repository = $repository;
+        $this->fileStore = $fileStore;
     }
 
     public function output(DOMDocument $document, CpeCdrResult $result): ?string

--- a/src/Services/Cdr/CdrBridge.php
+++ b/src/Services/Cdr/CdrBridge.php
@@ -6,6 +6,7 @@ namespace App\Services\Cdr;
 
 use App\Entity\CpeDocument;
 use App\Model\CpeCdrResult;
+use App\Services\File\FileStoreInterface;
 use App\Services\Xml\HashExtract;
 use DateTime;
 use Doctrine\ORM\EntityManagerInterface;
@@ -20,6 +21,8 @@ class CdrBridge implements CdrOutputInterface
     private HashExtract $hashExtractor;
 
     private EntityManagerInterface $repository;
+
+    private FileStoreInterface $fileStore;
 
     /**
      * CdrBridge constructor.
@@ -58,8 +61,8 @@ class CdrBridge implements CdrOutputInterface
             ->setTicket($result->getTicket())
         ;
 
-        $document->save($cpe->getName().'.xml');
-        file_put_contents('R-'.$cpe->getName().'.xml', $cdr);
+        $this->fileStore->save($cpe->getName().'.xml', $document->saveXML());
+        $this->fileStore->save('R-'.$cpe->getName().'.xml', $cdr);
 
         $this->repository->persist($cpe);
         $this->repository->flush();

--- a/src/Services/Cdr/CdrBridge.php
+++ b/src/Services/Cdr/CdrBridge.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace App\Services\Cdr;
 
+use App\Entity\CpeDocument;
 use App\Model\CpeCdrResult;
+use App\Services\Xml\HashExtract;
+use DateTime;
+use Doctrine\ORM\EntityManagerInterface;
 use DOMDocument;
 
 class CdrBridge implements CdrOutputInterface
@@ -13,22 +17,53 @@ class CdrBridge implements CdrOutputInterface
 
     private CdrWriterInterface $cdrWriter;
 
+    private HashExtract $hashExtractor;
+
+    private EntityManagerInterface $repository;
+
     /**
      * CdrBridge constructor.
      *
      * @param AppCdrCreatorInterface $appCdrCreator
      * @param CdrWriterInterface $cdrWriter
+     * @param HashExtract $hashExtractor
+     * @param EntityManagerInterface $repository
      */
-    public function __construct(AppCdrCreatorInterface $appCdrCreator, CdrWriterInterface $cdrWriter)
+    public function __construct(AppCdrCreatorInterface $appCdrCreator, CdrWriterInterface $cdrWriter, HashExtract $hashExtractor, EntityManagerInterface $repository)
     {
         $this->appCdrCreator = $appCdrCreator;
         $this->cdrWriter = $cdrWriter;
+        $this->hashExtractor = $hashExtractor;
+        $this->repository = $repository;
     }
 
     public function output(DOMDocument $document, CpeCdrResult $result): ?string
     {
         $appCdr = $this->appCdrCreator->create($document, $result);
+        $cdr = $this->cdrWriter->write($appCdr);
 
-        return $this->cdrWriter->write($appCdr);
+        $cpe = $this->repository->getRepository(CpeDocument::class)
+                            ->findOneByName($appCdr->getFilename());
+
+        if ($cpe === null) {
+            $cpe = new CpeDocument();
+        }
+
+        $cpe
+            ->setName($appCdr->getFilename())
+            ->setStateCode($result->getCodeResult())
+            ->setHashCpe($this->hashExtractor->fromDoc($document))
+            ->setHashCdr($this->hashExtractor->fromXml($cdr))
+            ->setCreateDate(new DateTime())
+            ->setTicket($result->getTicket())
+        ;
+
+        $document->save($cpe->getName().'.xml');
+        file_put_contents('R-'.$cpe->getName().'.xml', $cdr);
+
+        $this->repository->persist($cpe);
+        $this->repository->flush();
+
+        return $cdr;
     }
 }

--- a/src/Services/Cdr/CdrBridge.php
+++ b/src/Services/Cdr/CdrBridge.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Cdr;
 
-use App\Entity\CpeCdrResult;
+use App\Model\CpeCdrResult;
 use DOMDocument;
 
 class CdrBridge implements CdrOutputInterface

--- a/src/Services/Cdr/CdrBridge.php
+++ b/src/Services/Cdr/CdrBridge.php
@@ -9,15 +9,9 @@ use DOMDocument;
 
 class CdrBridge implements CdrOutputInterface
 {
-    /**
-     * @var AppCdrCreatorInterface
-     */
-    private $appCdrCreator;
+    private AppCdrCreatorInterface $appCdrCreator;
 
-    /**
-     * @var CdrWriterInterface
-     */
-    private $cdrWriter;
+    private CdrWriterInterface $cdrWriter;
 
     /**
      * CdrBridge constructor.

--- a/src/Services/Cdr/CdrOutputInterface.php
+++ b/src/Services/Cdr/CdrOutputInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Cdr;
 
-use App\Entity\CpeCdrResult;
+use App\Model\CpeCdrResult;
 use DOMDocument;
 
 interface CdrOutputInterface

--- a/src/Services/Cdr/CdrWriterInterface.php
+++ b/src/Services/Cdr/CdrWriterInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Cdr;
 
-use App\Entity\ApplicationResponse;
+use App\Model\ApplicationResponse;
 
 interface CdrWriterInterface
 {

--- a/src/Services/Cdr/XmlAppCdrCreator.php
+++ b/src/Services/Cdr/XmlAppCdrCreator.php
@@ -13,29 +13,20 @@ use Greenter\Ws\Reader\FilenameExtractorInterface;
 
 class XmlAppCdrCreator implements AppCdrCreatorInterface
 {
-    /**
-     * @var string
-     */
-    private $oseRuc;
+    private ?string $oseRuc;
 
-    /**
-     * @var FilenameExtractorInterface
-     */
-    private $filenameResolver;
+    private FilenameExtractorInterface $filenameResolver;
 
-    /**
-     * @var XmlParserInterface
-     */
-    private $xmlParser;
+    private XmlParserInterface $xmlParser;
 
     /**
      * XmlAppCdrCreator constructor.
      *
-     * @param string $oseRuc
+     * @param string|null $oseRuc
      * @param FilenameExtractorInterface $filenameResolver
      * @param XmlParserInterface $xmlParser
      */
-    public function __construct(string $oseRuc, FilenameExtractorInterface $filenameResolver, XmlParserInterface $xmlParser)
+    public function __construct(?string $oseRuc, FilenameExtractorInterface $filenameResolver, XmlParserInterface $xmlParser)
     {
         $this->oseRuc = $oseRuc;
         $this->filenameResolver = $filenameResolver;

--- a/src/Services/Cdr/XmlAppCdrCreator.php
+++ b/src/Services/Cdr/XmlAppCdrCreator.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace App\Services\Cdr;
 
-use App\Entity\ApplicationResponse;
-use App\Entity\CpeCdrResult;
+use App\Model\ApplicationResponse;
+use App\Model\CpeCdrResult;
 use App\Services\Xml\XmlParserInterface;
 use DateTime;
 use DOMDocument;

--- a/src/Services/Cdr/XmlCdrWriter.php
+++ b/src/Services/Cdr/XmlCdrWriter.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Cdr;
 
-use App\Entity\ApplicationResponse;
+use App\Model\ApplicationResponse;
 use Greenter\XMLSecLibs\Sunat\SignedXml;
 use Twig\Environment;
 

--- a/src/Services/Cdr/ZipCdrWriter.php
+++ b/src/Services/Cdr/ZipCdrWriter.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Cdr;
 
-use App\Entity\ApplicationResponse;
+use App\Model\ApplicationResponse;
 use App\Services\Zip\XmlZipInterface;
 
 class ZipCdrWriter implements CdrWriterInterface

--- a/src/Services/CredentialStore.php
+++ b/src/Services/CredentialStore.php
@@ -9,10 +9,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 class CredentialStore
 {
-    /**
-     * @var ParameterBagInterface
-     */
-    private $params;
+    private ParameterBagInterface $params;
 
     /**
      * CredentialStore constructor.

--- a/src/Services/CredentialStore.php
+++ b/src/Services/CredentialStore.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services;
 
-use App\Entity\SoapCredential;
+use App\Model\SoapCredential;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 class CredentialStore

--- a/src/Services/File/FileStoreInterface.php
+++ b/src/Services/File/FileStoreInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\File;
+
+interface FileStoreInterface
+{
+    /**
+     * Save file
+     * @param string $filename
+     * @param string|null $content
+     */
+    public function save(string $filename, ?string $content): void;
+
+    /**
+     * Get saved file
+     *
+     * @param string $filename
+     * @return string|null
+     */
+    public function get(string $filename): ?string;
+}

--- a/src/Services/File/SystemFileStore.php
+++ b/src/Services/File/SystemFileStore.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\File;
+
+use Psr\Log\LoggerInterface;
+
+class SystemFileStore implements FileStoreInterface
+{
+    /**
+     * Directory to save files.
+     *
+     * @var string
+     */
+    private string $uploadDir;
+
+    private LoggerInterface $logger;
+
+    /**
+     * SystemFileStore constructor.
+     * @param string $uploadDir
+     * @param LoggerInterface $logger
+     */
+    public function __construct(string $uploadDir, LoggerInterface $logger)
+    {
+        $this->uploadDir = $uploadDir;
+        $this->logger = $logger;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function save(string $filename, ?string $content): void
+    {
+        $fullPath = $this->uploadDir.DIRECTORY_SEPARATOR.$filename;
+        file_put_contents($fullPath, $content);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function get(string $filename): ?string
+    {
+        $fullPath = $this->uploadDir.DIRECTORY_SEPARATOR.$filename;
+        if (!file_exists($fullPath)) {
+            $this->logger->warning('File not found: '.$fullPath);
+            return null;
+        }
+
+        $content = file_get_contents($fullPath);
+        if ($content === false) {
+            $this->logger->warning('File cannot read: '.$fullPath);
+            return null;
+        }
+
+        return $content;
+    }
+}

--- a/src/Services/File/SystemFileStore.php
+++ b/src/Services/File/SystemFileStore.php
@@ -33,6 +33,10 @@ class SystemFileStore implements FileStoreInterface
      */
     public function save(string $filename, ?string $content): void
     {
+        if (!is_dir($this->uploadDir)) {
+            mkdir($this->uploadDir, 0777, true);
+        }
+
         $fullPath = $this->uploadDir.DIRECTORY_SEPARATOR.$filename;
         file_put_contents($fullPath, $content);
     }

--- a/src/Services/Soap/ExceptionCreator.php
+++ b/src/Services/Soap/ExceptionCreator.php
@@ -34,4 +34,12 @@ class ExceptionCreator
             $error->getDetail(),
         );
     }
+
+    public function fromCode(string $code): SoapFault
+    {
+        return new SoapFault(
+            $code,
+            $this->codeResolver->getValue($code),
+        );
+    }
 }

--- a/src/Services/Soap/ExceptionCreator.php
+++ b/src/Services/Soap/ExceptionCreator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Soap;
 
-use App\Entity\ValidationError;
+use App\Model\ValidationError;
 use Greenter\Validator\ErrorCodeProviderInterface;
 use SoapFault;
 

--- a/src/Services/Util/Mapper.php
+++ b/src/Services/Util/Mapper.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Services;
+namespace App\Services\Util;
 
 class Mapper
 {

--- a/src/Services/Xml/DomXmlParser.php
+++ b/src/Services/Xml/DomXmlParser.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Xml;
 
-use App\Entity\MinimalDocInfo;
+use App\Model\MinimalDocInfo;
 use DOMDocument;
 use DOMElement;
 use DOMNode;

--- a/src/Services/Xml/FileSystemXslDocResolver.php
+++ b/src/Services/Xml/FileSystemXslDocResolver.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Xml;
+
+use DOMDocument;
+use Greenter\Validator\Resolver\RuleResolverInterface;
+use Greenter\Validator\Resolver\TypeResolverInterface;
+
+class FileSystemXslDocResolver implements XslDocResolverInterface
+{
+    private TypeResolverInterface $typeResolver;
+    private RuleResolverInterface $ruleResolver;
+
+    /**
+     * FileSystemXslDocResolver constructor.
+     *
+     * @param TypeResolverInterface $typeResolver
+     * @param RuleResolverInterface $ruleResolver
+     */
+    public function __construct(TypeResolverInterface $typeResolver, RuleResolverInterface $ruleResolver)
+    {
+        $this->typeResolver = $typeResolver;
+        $this->ruleResolver = $ruleResolver;
+    }
+
+    public function fromDoc(DOMDocument $document): ?DOMDocument
+    {
+        $type = $this->typeResolver->getType($document);
+        $path = $this->ruleResolver->getPath($type);
+        if ($path === null || !file_exists($path)) {
+            return null;
+        }
+
+        $xslDoc = new DOMDocument();
+        $xslDoc->load($path);
+
+        return $xslDoc;
+    }
+}

--- a/src/Services/Xml/HashExtract.php
+++ b/src/Services/Xml/HashExtract.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Xml;
+
+use DOMDocument;
+use DOMXPath;
+
+class HashExtract
+{
+    private const DIGEST_QUERY = 'ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/ds:Signature/ds:SignedInfo/ds:Reference/ds:DigestValue';
+
+    public function fromXml(?string $xml): ?string
+    {
+        $doc = new DOMDocument();
+        $doc->loadXML($xml);
+
+        return $this->fromDoc($doc);
+    }
+
+    public function fromDoc(DOMDocument $document): ?string
+    {
+        $xpath = new DOMXPath($document);
+        $node = $xpath->query(self::DIGEST_QUERY, $document->documentElement);
+        if ($node === false || $node->count() === 0) {
+            return null;
+        }
+
+        return $node->item(0)->nodeValue;
+    }
+}

--- a/src/Services/Xml/XmlParserInterface.php
+++ b/src/Services/Xml/XmlParserInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Xml;
 
-use App\Entity\MinimalDocInfo;
+use App\Model\MinimalDocInfo;
 use DOMDocument;
 
 interface XmlParserInterface

--- a/src/Services/Xml/XslDocResolverInterface.php
+++ b/src/Services/Xml/XslDocResolverInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Xml;
+
+use DOMDocument;
+
+interface XslDocResolverInterface
+{
+    public function fromDoc(DOMDocument $document): ?DOMDocument;
+}

--- a/src/Services/Zip/XmlFilenameDecorator.php
+++ b/src/Services/Zip/XmlFilenameDecorator.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace App\Services\Zip;
 
-use App\Entity\ValidationError;
-use App\Entity\ValueResult;
+use App\Model\ValidationError;
+use App\Model\ValueResult;
 
 class XmlFilenameDecorator implements XmlZipInterface
 {

--- a/src/Services/Zip/XmlZipFly.php
+++ b/src/Services/Zip/XmlZipFly.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\Services\Zip;
 
-use App\Entity\ErrorCodeList;
-use App\Entity\ValidationError;
-use App\Entity\ValueResult;
+use App\Model\ErrorCodeList;
+use App\Model\ValidationError;
+use App\Model\ValueResult;
 use PhpZip\Exception\ZipException;
 use PhpZip\ZipFile;
 

--- a/src/Services/Zip/XmlZipInterface.php
+++ b/src/Services/Zip/XmlZipInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Zip;
 
-use App\Entity\ValueResult;
+use App\Model\ValueResult;
 
 interface XmlZipInterface
 {

--- a/src/Validator/CpeXslValidator.php
+++ b/src/Validator/CpeXslValidator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Validator;
 
-use App\Entity\ValidationError;
+use App\Model\ValidationError;
 use DOMDocument;
 
 class CpeXslValidator implements XmlValidatorInterface

--- a/src/Validator/CpeXslValidator.php
+++ b/src/Validator/CpeXslValidator.php
@@ -5,12 +5,43 @@ declare(strict_types=1);
 namespace App\Validator;
 
 use App\Model\ValidationError;
+use App\Services\Xml\XslDocResolverInterface;
 use DOMDocument;
+use Greenter\Validator\Xml\XslValidator;
 
 class CpeXslValidator implements XmlValidatorInterface
 {
+    private XslValidator $validator;
+
+    private XslDocResolverInterface $xslDocResolver;
+
+    /**
+     * CpeXslValidator constructor.
+     *
+     * @param XslValidator $validator
+     * @param XslDocResolverInterface $xslDocResolver
+     */
+    public function __construct(XslValidator $validator, XslDocResolverInterface $xslDocResolver)
+    {
+        $this->validator = $validator;
+        $this->xslDocResolver = $xslDocResolver;
+    }
+
     public function validate(string $filename, DOMDocument $document): ?ValidationError
     {
-        return null;
+        $xslDoc = $this->xslDocResolver->fromDoc($document);
+        if ($xslDoc === null) {
+            return null;
+        }
+
+        $this->validator->setXsl($xslDoc);
+        $result = $this->validator->validate($filename, $document);
+        if (count($result) === 0) {
+            return null;
+        }
+
+        $mapErrors = array_map(fn($error) => new ValidationError($error->getCode(), $error->getMessage()), $result);
+
+        return $mapErrors[0];
     }
 }

--- a/src/Validator/CpeXslValidator.php
+++ b/src/Validator/CpeXslValidator.php
@@ -7,6 +7,7 @@ namespace App\Validator;
 use App\Model\ValidationError;
 use App\Services\Xml\XslDocResolverInterface;
 use DOMDocument;
+use Greenter\Validator\Entity\CpeError;
 use Greenter\Validator\Xml\XslValidator;
 
 class CpeXslValidator implements XmlValidatorInterface
@@ -40,8 +41,13 @@ class CpeXslValidator implements XmlValidatorInterface
             return null;
         }
 
-        $mapErrors = array_map(fn($error) => new ValidationError($error->getCode(), $error->getMessage()), $result);
+        $mapErrors = array_map(fn($error) => new ValidationError($error->getCode(), $this->getErrorMessage($error)), $result);
 
         return $mapErrors[0];
+    }
+
+    private function getErrorMessage(CpeError $error): string
+    {
+        return $error->getMessage().' (Nodo: '.$error->getNodePath().'='.$error->getNodeValue().').';
     }
 }

--- a/src/Validator/MultiValidator.php
+++ b/src/Validator/MultiValidator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Validator;
 
-use App\Entity\ValidationError;
+use App\Model\ValidationError;
 use DOMDocument;
 
 class MultiValidator implements XmlValidatorInterface

--- a/src/Validator/XmlSchemaValidator.php
+++ b/src/Validator/XmlSchemaValidator.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace App\Validator;
 
-use App\Entity\ErrorCodeList;
-use App\Entity\ValidationError;
+use App\Model\ErrorCodeList;
+use App\Model\ValidationError;
 use DOMDocument;
 use Greenter\Ubl\Resolver\PathResolverInterface;
 use Greenter\Ubl\SchemaValidatorInterface;

--- a/src/Validator/XmlSignValidator.php
+++ b/src/Validator/XmlSignValidator.php
@@ -14,7 +14,10 @@ class XmlSignValidator implements XmlValidatorInterface
     public function validate(string $filename, DOMDocument $document): ?ValidationError
     {
         $signValidator = new SignedXml();
+        // Avoid sign node remove.
+        $documentToVerify = new DOMDocument();
+        $documentToVerify->loadXML($document->saveXML());
 
-        return $signValidator->verify($document) ? null : new ValidationError(ErrorCodeList::XML_ALTERADO);
+        return $signValidator->verify($documentToVerify) ? null : new ValidationError(ErrorCodeList::XML_ALTERADO);
     }
 }

--- a/src/Validator/XmlSignValidator.php
+++ b/src/Validator/XmlSignValidator.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace App\Validator;
 
-use App\Entity\ErrorCodeList;
-use App\Entity\ValidationError;
+use App\Model\ErrorCodeList;
+use App\Model\ValidationError;
 use DOMDocument;
 use Greenter\XMLSecLibs\Sunat\SignedXml;
 

--- a/src/Validator/XmlValidatorInterface.php
+++ b/src/Validator/XmlValidatorInterface.php
@@ -2,7 +2,7 @@
 
 namespace App\Validator;
 
-use App\Entity\ValidationError;
+use App\Model\ValidationError;
 use DOMDocument;
 
 interface XmlValidatorInterface

--- a/symfony.lock
+++ b/symfony.lock
@@ -256,6 +256,21 @@
     "symfony/orm-pack": {
         "version": "v2.0.0"
     },
+    "symfony/phpunit-bridge": {
+        "version": "4.3",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "4.3",
+            "ref": "6d0e35f749d5f4bfe1f011762875275cd3f9874f"
+        },
+        "files": [
+            "./.env.test",
+            "./bin/phpunit",
+            "./phpunit.xml.dist",
+            "./tests/bootstrap.php"
+        ]
+    },
     "symfony/polyfill-intl-grapheme": {
         "version": "v1.18.1"
     },

--- a/symfony.lock
+++ b/symfony.lock
@@ -1,4 +1,86 @@
 {
+    "composer/package-versions-deprecated": {
+        "version": "1.11.99"
+    },
+    "doctrine/annotations": {
+        "version": "1.0",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "1.0",
+            "ref": "a2759dd6123694c8d901d0ec80006e044c2e6457"
+        },
+        "files": [
+            "./config/routes/annotations.yaml"
+        ]
+    },
+    "doctrine/cache": {
+        "version": "1.10.2"
+    },
+    "doctrine/collections": {
+        "version": "1.6.7"
+    },
+    "doctrine/common": {
+        "version": "3.0.2"
+    },
+    "doctrine/dbal": {
+        "version": "2.10.4"
+    },
+    "doctrine/doctrine-bundle": {
+        "version": "2.0",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "2.0",
+            "ref": "a9f2463b9f73efe74482f831f03a204a41328555"
+        },
+        "files": [
+            "./config/packages/doctrine.yaml",
+            "./config/packages/prod/doctrine.yaml",
+            "./src/Entity/.gitignore",
+            "./src/Repository/.gitignore"
+        ]
+    },
+    "doctrine/doctrine-migrations-bundle": {
+        "version": "2.2",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "2.2",
+            "ref": "baaa439e3e3179e69e3da84b671f0a3e4a2f56ad"
+        },
+        "files": [
+            "./config/packages/doctrine_migrations.yaml",
+            "./migrations/.gitignore"
+        ]
+    },
+    "doctrine/event-manager": {
+        "version": "1.1.1"
+    },
+    "doctrine/inflector": {
+        "version": "1.4.3"
+    },
+    "doctrine/instantiator": {
+        "version": "1.3.1"
+    },
+    "doctrine/lexer": {
+        "version": "1.2.1"
+    },
+    "doctrine/migrations": {
+        "version": "3.0.1"
+    },
+    "doctrine/orm": {
+        "version": "v2.7.3"
+    },
+    "doctrine/persistence": {
+        "version": "2.0.0"
+    },
+    "doctrine/reflection": {
+        "version": "1.2.1"
+    },
+    "doctrine/sql-formatter": {
+        "version": "1.1.1"
+    },
     "greenter/core": {
         "version": "v4.0.2"
     },
@@ -17,11 +99,26 @@
     "greenter/xmldsig": {
         "version": "v5.0.3"
     },
+    "laminas/laminas-code": {
+        "version": "3.4.1"
+    },
+    "laminas/laminas-eventmanager": {
+        "version": "3.3.0"
+    },
+    "laminas/laminas-zendframework-bridge": {
+        "version": "1.1.1"
+    },
     "monolog/monolog": {
         "version": "2.1.1"
     },
     "nelexa/zip": {
         "version": "3.3.3"
+    },
+    "nikic/php-parser": {
+        "version": "v4.9.1"
+    },
+    "ocramius/proxy-manager": {
+        "version": "2.8.0"
     },
     "php": {
         "version": "7.4"
@@ -70,6 +167,9 @@
     },
     "symfony/deprecation-contracts": {
         "version": "v2.1.3"
+    },
+    "symfony/doctrine-bridge": {
+        "version": "v5.1.5"
     },
     "symfony/dotenv": {
         "version": "v5.1.3"
@@ -126,6 +226,15 @@
     "symfony/http-kernel": {
         "version": "v5.1.3"
     },
+    "symfony/maker-bundle": {
+        "version": "1.0",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "1.0",
+            "ref": "fadbfe33303a76e25cb63401050439aa9b1a9c7f"
+        }
+    },
     "symfony/monolog-bridge": {
         "version": "v5.1.3"
     },
@@ -143,6 +252,9 @@
             "./config/packages/prod/monolog.yaml",
             "./config/packages/test/monolog.yaml"
         ]
+    },
+    "symfony/orm-pack": {
+        "version": "v2.0.0"
     },
     "symfony/polyfill-intl-grapheme": {
         "version": "v1.18.1"
@@ -175,6 +287,9 @@
     },
     "symfony/service-contracts": {
         "version": "v2.1.3"
+    },
+    "symfony/stopwatch": {
+        "version": "v5.1.5"
     },
     "symfony/string": {
         "version": "v5.1.3"
@@ -216,5 +331,8 @@
     },
     "twig/twig": {
         "version": "v3.0.5"
+    },
+    "webimpress/safe-writer": {
+        "version": "2.1.0"
     }
 }

--- a/symfony.lock
+++ b/symfony.lock
@@ -141,6 +141,9 @@
     "psr/log": {
         "version": "1.1.3"
     },
+    "symfony/browser-kit": {
+        "version": "v5.1.5"
+    },
     "symfony/cache": {
         "version": "v5.1.3"
     },
@@ -169,6 +172,9 @@
         "version": "v2.1.3"
     },
     "symfony/doctrine-bridge": {
+        "version": "v5.1.5"
+    },
+    "symfony/dom-crawler": {
         "version": "v5.1.5"
     },
     "symfony/dotenv": {

--- a/tests/Controller/BillServiceControllerTest.php
+++ b/tests/Controller/BillServiceControllerTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Controller;
+
+use DOMDocument;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class BillServiceControllerTest extends WebTestCase
+{
+    public function testGetWsdl()
+    {
+        $client = static::createClient();
+
+        $client->request('GET', '/ol-ti-itcpe/billService?wsdl');
+
+        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+
+        $doc = new DOMDocument();
+        $doc->loadXML($client->getResponse()->getContent());
+
+        $this->assertStringContainsStringIgnoringCase('wsdl', $doc->documentElement->nodeName);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,11 @@
+<?php
+
+use Symfony\Component\Dotenv\Dotenv;
+
+require dirname(__DIR__).'/vendor/autoload.php';
+
+if (file_exists(dirname(__DIR__).'/config/bootstrap.php')) {
+    require dirname(__DIR__).'/config/bootstrap.php';
+} elseif (method_exists(Dotenv::class, 'bootEnv')) {
+    (new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
+}


### PR DESCRIPTION
- PHP 7.4 mínimo.
- Almacenamiento de comprobantes para poder usar  `getStatus` y `getStatusCdr`.
- Registro básico de comprobante en `sqlite` (puede usarse otros disponibles con `php_pdo`).
- Validación con reglas XSLT de SUNAT.